### PR TITLE
Skip end-to-end tests by default if lighthouse disabled

### DIFF
--- a/application/overlay/_twig/Jenkinsfile/test-end-to-end.twig
+++ b/application/overlay/_twig/Jenkinsfile/test-end-to-end.twig
@@ -1,7 +1,7 @@
+{% if @('services.lighthouse.enabled') %}
         stage('End-to-end Test') {
             parallel {
-{% if @('services.lighthouse.enabled') %}
                 stage('lighthouse') { steps { sh 'ws lighthouse' } }
-{% endif %}
             }
         }
+{% endif %}


### PR DESCRIPTION
Fixes #3