### PR TITLE
Download harness if not in isolated mode

### DIFF
--- a/application/overlay/_twig/Jenkinsfile/build.twig
+++ b/application/overlay/_twig/Jenkinsfile/build.twig
@@ -2,6 +2,10 @@
             steps {
 {% if @('jenkins.tests.use_global_services') %}
                 sh 'ws install'
+{% elseif not @('jenkins.tests.isolated') %}
+                sh 'ws harness download'
+                sh 'ws harness prepare'
+                sh 'ws enable'
 {% else %}
                 sh 'ws enable'
 {% endif %}


### PR DESCRIPTION
If the "build" step is the first step after git checkout, we don't have a .my127ws directory yet so we need to have that downloaded/extracted first