### PR TITLE
Include the project name in docker-compose project name in CI

### DIFF
--- a/harness/attributes/environment/pipeline.yml
+++ b/harness/attributes/environment/pipeline.yml
@@ -1,6 +1,6 @@
 
 attributes:
-  namespace: =exec("git log -n 1 --pretty=format:'%H'")
+  namespace: =@('workspace.name') ~ '-' ~ exec("git rev-parse --short HEAD")
   hostname: =@('workspace.name') ~ '.' ~ @('domain')
   app:
     build: static


### PR DESCRIPTION
So it's easier to identify the project from the instance shell

Also use a shorter git ref for it so it isn't too long