### PR TITLE
Add the second parameter to `tpl` function calls

### DIFF
--- a/helm/app/templates/application/console/deployment.yaml
+++ b/helm/app/templates/application/console/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               name: {{ $.Release.Name }}-console
           {{- end }}
           {{- with .envFrom }}
-          {{- tpl (. | toYaml) | nindent 10 }}
+          {{- tpl (. | toYaml) $ | nindent 10 }}
           {{- end }}
         {{- end }}
         image: {{ .image }}

--- a/helm/app/templates/cronjobs.yaml
+++ b/helm/app/templates/cronjobs.yaml
@@ -60,7 +60,7 @@ spec:
                     name: {{ print $.Release.Name "-" $serviceName }}
                 {{- end }}
                 {{- with .envFrom }}
-                {{- tpl (. | toYaml) | nindent 16 }}
+                {{- tpl (. | toYaml) $ | nindent 16 }}
                 {{- end }}
               {{- end }}
               image: {{ .image | quote }}

--- a/helm/app/templates/jobs.yaml
+++ b/helm/app/templates/jobs.yaml
@@ -54,7 +54,7 @@ spec:
                 name: {{ print $.Release.Name "-" $serviceName }}
             {{- end }}
             {{- with .envFrom }}
-            {{- tpl (. | toYaml) | nindent 12 }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}
           {{- end }}
           image: {{ .image | quote }}


### PR DESCRIPTION
in three helm template the `tpl` function was called without specifying the required second parameter.
This PR adds `$` as such parameter in the same way the other `tpl` calls are doing.