### PR TITLE
Publish only the default branch by default

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -34,7 +34,7 @@ attributes.default:
       enabled: false
       services: = publishable_services(@('services'))
       # branches that should publish (other than change requests and qa)
-      # use '*' if required to publish all branches
+      # use ANT glob syntax to match multiple branches
       branches:
         - = @('git.default_branch')
       # For defining environment variables in Jenkins, e.g. loading up docker username/password from a Jenkins

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -34,9 +34,9 @@ attributes.default:
       enabled: false
       services: = publishable_services(@('services'))
       # branches that should publish (other than change requests and qa)
-      # * is deprecated and will be limited to one branch by default in a future release
+      # use '*' if required to publish all branches
       branches:
-        - '*'
+        - = @('git.default_branch')
       # For defining environment variables in Jenkins, e.g. loading up docker username/password from a Jenkins
       # credential
       environment: {}


### PR DESCRIPTION
While it would be nice to use PR labels to choose intentionally to publish for preview environments, we need the current publishing of all branches to stop

If a project needs it, they can change the setting back, or specify the branch that wants previewing, until a PR label solution is done