### PR TITLE
Allow defining replicas from attributes for application deployments, ...

### DIFF
--- a/helm/app/templates/application/console/deployment.yaml
+++ b/helm/app/templates/application/console/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "15"
 spec:
-  replicas: 1
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:


### PR DESCRIPTION
…removing the existing setting by default

While its not relevant to scale console beyond 1, it may be useful to scale to 0 without "enabled: false" removing the deployment and any related resources