### PR TITLE
Switch kubeval's k8s spec location to fork

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -184,6 +184,8 @@ attributes.default:
       # or in helm chart repositories
       # requires sealed-secrets k8s operator
       sealed_secrets: true
+    # currently limited to versions supplied by https://github.com/inviqa/kubernetes-json-schema/tree/master/docs/schema
+    kubernetes_version: 1.21.9
     timeout: 300
 
     sealed_secrets:

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -66,6 +66,7 @@ command('helm template <chart-path>'):
 command('helm kubeval [--cleanup] <chart-path>'):
   env:
     CHART_PATH: = input.argument('chart-path')
+    K8S_VERSION: = @('helm.kubernetes_version')
     NAMESPACE: = @('pipeline.' ~ input.argument('environment') ~ '.namespace')
     ADDITIONAL_SCHEMA_LOCATIONS: = @('helm.additional_schema_locations')
     CLEANUP: "= input.option('cleanup') ? 1 : 0"
@@ -82,7 +83,10 @@ command('helm kubeval [--cleanup] <chart-path>'):
     fi
 
     passthru helm plugin install https://github.com/inviqa/helm-kubeval || true
-    KUBEVAL_OPTS=()
+    KUBEVAL_OPTS=(
+      --kubernetes-version "${K8S_VERSION}"
+      --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
+    )
 
     if [ -n "${ADDITIONAL_SCHEMA_LOCATIONS:-}" ]; then
       KUBEVAL_OPTS+=(--additional-schema-locations "${ADDITIONAL_SCHEMA_LOCATIONS}")


### PR DESCRIPTION
and limit it to a release before 1.22 to currently avoid it's obsoletions

https://github.com/instrumenta/kubernetes-json-schema hasn't been updated since 1.18.1 and we're using later versions now.

Since there are no obsoletions until 1.22, test against 1.21