### PR TITLE
Fix wrong platform mysql image on arm64 with new mysql:8.0-oracle image

### DIFF
--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -204,9 +204,9 @@ attributes.default:
       scope: "= @('helm.sealed_secrets.namespace') ? 'namespace-wide' : 'cluster-wide'"
 
   mysql:
-    # prefer native platform mysql image. _/mysql doesn't have arm64 images
-    image: "= host_architecture() == 'amd64' ? 'mysql' : 'mysql/mysql-server'"
-    tag: 8.0
+    image: mysql
+    # arm64 support is currently in a different tag
+    tag: "= host_architecture() == 'amd64' ? '8.0' : '8.0-oracle'"
 
   rabbitmq:
     image: rabbitmq


### PR DESCRIPTION
Also fixes 8.0 being interpreted as 8

mysql/mysql-server:8.0 stopped being a multi-platform image sometime after it was implemented here