### PR TITLE
Update CronJob and PodDisruptionBudget for k8s 1.25 support

### DIFF
--- a/helm/app/templates/cronjobs.yaml
+++ b/helm/app/templates/cronjobs.yaml
@@ -4,7 +4,7 @@
 {{- range $cronName, $cronConfig := $service.cronjobs }}
 {{- with (mergeOverwrite (deepCopy $service) (deepCopy $cronConfig)) }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ print $.Release.Name "-" $cronName }}

--- a/helm/app/templates/pod-disrution-budgets.yaml
+++ b/helm/app/templates/pod-disrution-budgets.yaml
@@ -5,7 +5,7 @@
 {{- $autoscaling := .autoscaling | default (dict "minReplicas" 0) -}}
 {{- if or (gt (.replicas | default 1 | int) 1) (and $autoscaling.enabled (gt ($autoscaling.minReplicas | int) 1)) }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ print $.Release.Name "-" $serviceName }}


### PR DESCRIPTION
This drops support for k8s 1.20 and lower