### PR TITLE
Conditionally upgrade CronJob/HPA/PDB for k8s 1.25 and 1.26 support

### DIFF
--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -52,6 +52,7 @@ command('app deploy <environment>'):
 command('helm template <chart-path>'):
   env:
     CHART_PATH:  = input.argument('chart-path')
+    K8S_VERSION: = @('helm.kubernetes_version')
     NAMESPACE:   = @('pipeline.' ~ input.argument('environment') ~ '.namespace')
   exec: |
     #!bash(harness:/helm)|=
@@ -61,7 +62,7 @@ command('helm template <chart-path>'):
       passthru helm init --client-only
     fi
     passthru helm dependency build
-    passthru helm template .
+    passthru helm template --kubernetes-version "${K8S_VERSION}" .
 
 command('helm kubeval [--cleanup] <chart-path>'):
   env:

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -62,7 +62,7 @@ command('helm template <chart-path>'):
       passthru helm init --client-only
     fi
     passthru helm dependency build
-    passthru helm template --kubernetes-version "${K8S_VERSION}" .
+    passthru helm template --kube-version "${K8S_VERSION}" .
 
 command('helm kubeval [--cleanup] <chart-path>'):
   env:

--- a/helm/app/templates/cronjobs.yaml
+++ b/helm/app/templates/cronjobs.yaml
@@ -4,7 +4,11 @@
 {{- range $cronName, $cronConfig := $service.cronjobs }}
 {{- with (mergeOverwrite (deepCopy $service) (deepCopy $cronConfig)) }}
 ---
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.Version }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ print $.Release.Name "-" $cronName }}

--- a/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -4,7 +4,11 @@
 {{- $autoscaling := .autoscaling | default (dict) -}}
 {{- if and (not (hasPrefix "." $serviceName)) .enabled $autoscaling.enabled }}
 ---
+{{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
+apiVersion: autoscaling/v2
+{{- else }}
 apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ print $.Release.Name "-" $serviceName }}

--- a/helm/app/templates/pod-disrution-budgets.yaml
+++ b/helm/app/templates/pod-disrution-budgets.yaml
@@ -5,7 +5,11 @@
 {{- $autoscaling := .autoscaling | default (dict "minReplicas" 0) -}}
 {{- if or (gt (.replicas | default 1 | int) 1) (and $autoscaling.enabled (gt ($autoscaling.minReplicas | int) 1)) }}
 ---
+{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ print $.Release.Name "-" $serviceName }}


### PR DESCRIPTION
Since not all clusters are required to be on k8s 1.21+ yet, use helm's capabilities to conditionally upgrade it.

ArgoCD also passes the cluster's version to its helm template render