### PR TITLE
Use underscore prefix to denote service templates

### DIFF
--- a/helm/app/templates/cronjobs.yaml
+++ b/helm/app/templates/cronjobs.yaml
@@ -1,6 +1,6 @@
 {{- range $serviceName := (.Values.services | keys) -}}
 {{- $service := include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml -}}
-{{- if and (not (hasPrefix "." $serviceName)) $service.cronjobs -}}
+{{- if and (not (hasPrefix "_" $serviceName)) $service.cronjobs -}}
 {{- range $cronName, $cronConfig := $service.cronjobs }}
 {{- with (mergeOverwrite (deepCopy $service) (deepCopy $cronConfig)) }}
 ---

--- a/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -2,7 +2,7 @@
 {{- $service := include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml -}}
 {{- with $service }}
 {{- $autoscaling := .autoscaling | default (dict) -}}
-{{- if and (not (hasPrefix "." $serviceName)) .enabled $autoscaling.enabled }}
+{{- if and (not (hasPrefix "_" $serviceName)) .enabled $autoscaling.enabled }}
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler

--- a/helm/app/templates/jobs.yaml
+++ b/helm/app/templates/jobs.yaml
@@ -1,6 +1,6 @@
 {{- range $serviceName := (.Values.services | keys) -}}
 {{- $service := include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml -}}
-{{- if and (not (hasPrefix "." $serviceName)) $service.jobs -}}
+{{- if and (not (hasPrefix "_" $serviceName)) $service.jobs -}}
 {{- range $jobName, $jobConfig := $service.jobs }}
 {{- with (mergeOverwrite (deepCopy $service) (deepCopy $jobConfig))}}
 ---

--- a/helm/app/templates/pod-disrution-budgets.yaml
+++ b/helm/app/templates/pod-disrution-budgets.yaml
@@ -1,7 +1,7 @@
 {{- range $serviceName := (.Values.services | keys) -}}
 {{- $service := include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml -}}
 {{- with $service }}
-{{- if and (not (hasPrefix "." $serviceName)) .enabled }}
+{{- if and (not (hasPrefix "_" $serviceName)) .enabled }}
 {{- $autoscaling := .autoscaling | default (dict "minReplicas" 0) -}}
 {{- if or (gt (.replicas | default 1 | int) 1) (and $autoscaling.enabled (gt ($autoscaling.minReplicas | int) 1)) }}
 ---

--- a/helm/app/templates/service-secrets.yaml
+++ b/helm/app/templates/service-secrets.yaml
@@ -1,6 +1,6 @@
 {{- range $serviceName := ($.Values.services | keys) -}}
 {{- with (include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml) }}
-{{ if not (hasPrefix "." $serviceName) -}}
+{{ if not (hasPrefix "_" $serviceName) -}}
 ---
 {{ template "service.environment.secret" (dict "service_name" $serviceName "service" . "root" $) }}
 {{- end }}


### PR DESCRIPTION
So that it can be defined in workspace attributes as well as helm values