### PR TITLE
Use ARM-compatible tag of official varnish docker image

### DIFF
--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -84,7 +84,8 @@ attributes:
       major_version: 8
       port: 8983
     varnish:
-      image: varnish:6
+      # 6.0 is LTS
+      image: varnish:6.0
       environment:
         VARNISH_SIZE: "1024M"
       resources:


### PR DESCRIPTION
6 tracked 6.x, but 6.x other than 6.0 are EOL. 6.0 is a LTS version