### PR TITLE
Add support for defining affinity and self service antiAffinity

### DIFF
--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -98,6 +98,9 @@ attributes:
         memory: "1124Mi"
   pipeline:
     base:
+      global:
+        affinity:
+          selfAntiAffinityTopologyKey: ~
       prometheus:
         podMonitoring: false
       services:

--- a/helm/app/templates/_base_helper.tpl
+++ b/helm/app/templates/_base_helper.tpl
@@ -85,3 +85,28 @@ stringData:
 {{ end }}
 {{ end }}
 {{- end }}
+
+{{- define "pod.selfAntiAffinity" -}}
+{{- $topologyKey := (.service.affinity | default (dict)).selfAntiAffinityTopologyKey | default .root.Values.global.affinity.selfAntiAffinityTopologyKey }}
+{{- if $topologyKey }}
+preferredDuringSchedulingIgnoredDuringExecution:
+  - weight: 100
+    podAffinityTerm:
+      labelSelector:
+        matchLabels:
+          app.service: {{ print .root.Release.Name "-" .serviceName }}
+      topologyKey: {{ $topologyKey }}
+{{- end }}
+{{- end -}}
+
+{{- define "pod.affinity" -}}
+{{- $selfAntiAffinity := (include "pod.selfAntiAffinity" .) | fromYaml | default (dict) -}}
+{{- $affinity := omit (deepCopy (.service.affinity | default (dict) )) "selfAntiAffinityTopologyKey" -}}
+{{- if $selfAntiAffinity -}}
+  {{- $_ := set $affinity "podAntiAffinity" (index $affinity "podAntiAffinity" | default (dict)) -}}
+  {{- range $key, $value := pick $selfAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution" "requiredDuringSchedulingIgnoredDuringExecution" -}}
+    {{- $_ := set $affinity.podAntiAffinity $key (concat (index $affinity.podAntiAffinity $key | default (list)) ($value)) -}}
+  {{- end -}}
+{{- end -}}
+{{ $affinity | toYaml }}
+{{- end -}}

--- a/helm/app/templates/application/console/deployment.yaml
+++ b/helm/app/templates/application/console/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/component: console
         app.service: {{ $.Release.Name }}-console
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "console" "service" .) | nindent 8 }}
       containers:
       - env:
         {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}

--- a/helm/app/templates/service/varnish/statefulset.yaml
+++ b/helm/app/templates/service/varnish/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/component: varnish
         app.service: {{ $.Release.Name }}-varnish
     spec:
+      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "console" "service" .) | nindent 8 }}
       containers:
       - name: varnish
         image: {{ .image | quote }}

--- a/helm/app/values-preview.yaml.twig
+++ b/helm/app/values-preview.yaml.twig
@@ -1,3 +1,6 @@
+{% if @('pipeline.preview.global') %}
+global: {{ to_nice_yaml(@('pipeline.preview.global'), 2, 2) | raw }}  
+{% endif %}
 {% if @('pipeline.preview.services') %}
 services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) | raw }}  
 {% endif %}

--- a/helm/app/values-production.yaml.twig
+++ b/helm/app/values-production.yaml.twig
@@ -1,3 +1,6 @@
+{% if @('pipeline.production.global') %}
+global: {{ to_nice_yaml(@('pipeline.production.global'), 2, 2) | raw }}  
+{% endif %}
 {% if @('pipeline.production.services') %}
 services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 2) | raw }}  
 {% endif %}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -4,6 +4,8 @@ feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
 
 ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
 
+global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) | raw }}
+
 docker:
   image_pull_config: {{ @('docker.image_pull_config') | raw }}
 


### PR DESCRIPTION
It's a common need to space out replicas so they are more guaranteed to be in separate zones or hosts, so a global setting can set the topologyKey across all replicable services.

Also support direct affinity configuration as well, merging the specific setting arrays together