### PR TITLE
Move global helm value settings to a global key

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,15 @@
 
 ## Upgrading from 0.1.x to 0.2.x
 
+### Attributes and helm values keys moved
+
+The following attributes were moved to a new key:
+
+* `helm.feature.sealed_secrets` -> `pipeline.base.global.sealed_secrets.enabled`
+* `pipeline.base.prometheus.podmonitoring` -> `pipeline.base.global.prometheus.podmonitoring`
+
+As such, they have also been moved in the helm values to their respective global configuration maps.
+
 ### Solr image now built and deployable
 
 The solr service previously was only usable for local development, but in some cases this may need to be deployed, so the service has a build step now.

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -178,12 +178,6 @@ attributes.default:
 
   helm:
     additional_schema_locations: https://inviqa.github.io/kubernetes-json-schema/schema
-    feature:
-      # Note: be very careful considering disabling this, as in most cases
-      # it causes the secrets in it to be stored plaintext on filesystem
-      # or in helm chart repositories
-      # requires sealed-secrets k8s operator
-      sealed_secrets: true
     # currently limited to versions supplied by https://github.com/inviqa/kubernetes-json-schema/tree/master/docs/schema
     kubernetes_version: 1.21.9
     timeout: 300
@@ -240,7 +234,6 @@ attributes.default:
 
   replicas:
     varnish: 1
-
   persistence:
     enabled: false
     mountVolumesOnConsole: true # possible to disable, but may lead to unexpected concequences with app init/migrate

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -101,8 +101,15 @@ attributes:
       global:
         affinity:
           selfAntiAffinityTopologyKey: ~
-      prometheus:
-        podMonitoring: false
+        prometheus:
+          podMonitoring: false
+        sealed_secrets:
+          # Note: be very careful considering disabling this, as in most cases
+          # it causes the secrets in it to be stored plaintext on filesystem
+          # or in helm chart repositories
+          # requires sealed-secrets k8s operator
+          enabled: true
+          scope: = @('helm.sealed_secrets.scope')
       services:
         mysql:
           options: = @('services.mysql.options')

--- a/helm/app/templates/_base_helper.tpl
+++ b/helm/app/templates/_base_helper.tpl
@@ -52,14 +52,14 @@ A template to fully resolve services that extend template services
 {{- end -}}
 
 {{- define "service.environment.secret" }}
-{{ if and .service.environment_secrets (.service.enabled | default true) }}
-{{ if .root.Values.feature.sealed_secrets }}
+{{- if and .service.environment_secrets (.service.enabled | default true) }}
+{{- if .root.Values.global.sealed_secrets.enabled }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
-{{ else }}
+{{- else }}
 apiVersion: v1
 kind: Secret
-{{ end }}
+{{- end }}
 metadata:
   name: {{ print .root.Release.Name "-" .service_name }}
   labels:
@@ -67,23 +67,23 @@ metadata:
     app.kubernetes.io/component: {{ .component | default .service_name }}
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-{{ if .root.Values.feature.sealed_secrets }}
-{{ if ne .root.Values.sealed_secrets.scope "strict" }}
-    sealedsecrets.bitnami.com/{{ .root.Values.sealed_secrets.scope }}: "true"
-{{ end }}
+{{- if .root.Values.global.sealed_secrets.enabled }}
+{{- if ne .root.Values.global.sealed_secrets.scope "strict" }}
+    sealedsecrets.bitnami.com/{{ .root.Values.global.sealed_secrets.scope }}: "true"
+{{- end }}
 spec:
   encryptedData:
-{{ index .service.environment_secrets | toYaml | nindent 4 }}
+{{- index .service.environment_secrets | toYaml | nindent 4 }}
   template:
     metadata:
       labels:
         {{- include "chart.labels" .root | nindent 8 }}
         app.kubernetes.io/component: {{ .component | default .service_name }}
-{{ else }}
+{{- else }}
 stringData:
-{{ index .service.environment_secrets | toYaml | nindent 2 -}}
-{{ end }}
-{{ end }}
+{{- index .service.environment_secrets | toYaml | nindent 2 -}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- define "pod.selfAntiAffinity" -}}

--- a/helm/app/templates/application/image-pull-config.yaml
+++ b/helm/app/templates/application/image-pull-config.yaml
@@ -1,5 +1,5 @@
-{{ if .Values.docker.image_pull_config }}
-{{ if .Values.feature.sealed_secrets }}
+{{- if .Values.docker.image_pull_config }}
+{{- if .Values.global.sealed_secrets.enabled }}
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 {{ else }}
@@ -10,8 +10,8 @@ metadata:
   name: {{ .Release.Name }}-image-pull-config
   annotations:
     argocd.argoproj.io/sync-wave: "1"
-{{ if .Values.feature.sealed_secrets }}
-    sealedsecrets.bitnami.com/cluster-wide: "true"
+{{- if .root.Values.global.sealed_secrets.enabled }}
+    sealedsecrets.bitnami.com/{{ .root.Values.global.sealed_secrets.scope }}: "true"
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:
@@ -22,9 +22,9 @@ spec:
         {{- include "chart.labels" $ | nindent 8 }}
   encryptedData:
     .dockerconfigjson: {{ .Values.docker.image_pull_config }}
-{{ else }}
+{{- else }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.docker.image_pull_config }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/helm/app/templates/podmonitors.yaml
+++ b/helm/app/templates/podmonitors.yaml
@@ -1,6 +1,6 @@
 {{- range $serviceName := (.Values.services | keys) -}}
 {{- with (include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml) }}
-{{- if and (not (hasPrefix "_" $serviceName)) $.Values.prometheus.podMonitoring (. | dig "metricsEnabled" true) .metricsEndpoints }}
+{{- if and (not (hasPrefix "_" $serviceName)) $.Values.global.prometheus.podMonitoring (. | dig "metricsEnabled" true) .metricsEndpoints }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/helm/app/templates/secrets.yaml
+++ b/helm/app/templates/secrets.yaml
@@ -4,9 +4,9 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   name: {{ print $.Release.Name "-" $secretName | quote }}
-{{ if ne $.Values.sealed_secrets.scope "strict" }}
+{{ if ne $.Values.global.sealed_secrets.scope "strict" }}
   annotations:
-    sealedsecrets.bitnami.com/{{ $.Values.sealed_secrets.scope }}: "true"
+    sealedsecrets.bitnami.com/{{ $.Values.global.sealed_secrets.scope }}: "true"
 {{ end }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -22,9 +22,4 @@ replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
 
 persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
 
-prometheus: {{ to_nice_yaml(@('pipeline.base.prometheus'), 2, 2) | raw }}
-
-sealed_secrets:
-  scope: {{ @('helm.sealed_secrets.scope') | json_encode | raw }}
-
 istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,7 +1,5 @@
 appVersion: {{ @('app.version') | json_encode | raw }}
 
-feature: {{ to_nice_yaml(@('helm.feature'), 2, 2) | raw }}
-
 ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
 
 global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) | raw }}


### PR DESCRIPTION
As these settings are getting more and more numerous, and didn't support preview and production overrides, use the common pattern of other vendor multi-application charts do of using a global value key.