### PR TITLE
Fix consistency of varnish replica configuration

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,8 +8,9 @@ The following attributes were moved to a new key:
 
 * `helm.feature.sealed_secrets` -> `pipeline.base.global.sealed_secrets.enabled`
 * `pipeline.base.prometheus.podmonitoring` -> `pipeline.base.global.prometheus.podmonitoring`
+* `replicas.varnish` -> `pipeline.base.services.varnish.replicas` # however the value has been removed, as the default is 1
 
-As such, they have also been moved in the helm values to their respective global configuration maps.
+As such, they have also been moved in the helm values to their respective global and services configuration maps.
 
 ### Solr image now built and deployable
 

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -232,8 +232,6 @@ attributes.default:
       s-maxage: ~
     target_service: nginx
 
-  replicas:
-    varnish: 1
   persistence:
     enabled: false
     mountVolumesOnConsole: true # possible to disable, but may lead to unexpected concequences with app init/migrate

--- a/helm/app/templates/service/varnish/statefulset.yaml
+++ b/helm/app/templates/service/varnish/statefulset.yaml
@@ -11,7 +11,9 @@ metadata:
     app.kubernetes.io/component: varnish
     app.service: {{ $.Release.Name }}-varnish
 spec:
-  replicas: {{ $.Values.replicas.varnish }}
+  {{- with (pick . "replicas") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
   podManagementPolicy: Parallel
   selector:
     matchLabels:

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -16,8 +16,6 @@ configMaps: {{ to_nice_yaml(@('pipeline.base.configMaps'), 2, 2) | raw }}
 
 secrets: {}
 
-replicas: {{ to_nice_yaml(@('replicas'), 2, 2) | raw }}
-
 persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
 
 istio: {{ to_nice_yaml(@('pipeline.base.istio'), 2, 2) | raw }}


### PR DESCRIPTION
services.*.replicas is needed for PodDisruptionBudget to be added, and for consistency with other services