### PR TITLE
Add support for sealed-secret template data in secrets

### DIFF
--- a/helm/app/templates/secrets.yaml
+++ b/helm/app/templates/secrets.yaml
@@ -26,4 +26,7 @@ spec:
         {{- if $config.labels }}
         {{- $config.labels | toYaml | nindent 8 }}
         {{- end }}
+{{- with (pick ($config.template | default (dict)) "data") }}
+    {{- . | toYaml | nindent 4 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Note: only supported in .Values.secrets due to the complexity representing the configuration. This can be mapped in pods as volumes or envFrom/environment[].valueFrom

This allows for go/template templating in plaintext values with access to the encryptedData unencrypted, allowing for example, configuration of an app that can't itself reference secrets or environment variables. e.g. https://github.com/bitnami-labs/sealed-secrets/blob/main/docs/examples/config-template/sealedsecret.yaml