### PR TITLE
Upgrade Redis and update configuration

### DIFF
--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -64,29 +64,49 @@ attributes.default:
       resources:
         memory: "1024Mi"
     redis:
-      image: redis:5-alpine
+      image: redis:6-alpine
       config:
-        options: 
-          maxmemory: '1073742000'
+        options:
+          # Handle many smaller keys
+          activedefrag: 'yes'
+          # 1Gi - 1024*1024*1024 bytes
+          maxmemory: '1073741824'
+          # Evict any least recently used key even if they don't have a TTL
           maxmemory-policy: allkeys-lru
-          save: 
-            - ['3600', '1']
-            - ['300', '100']
-            - ['60', '10000']
+          # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
+          # Redis < 7
+          # save: 
+          #   - ['3600', '1']
+          #   - ['300', '100']
+          #   - ['60', '10000']
+          # Redis >= 7
+          # save: 
+          #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
-        memory: "256Mi"
+        # 1.5 * maxmemory to allow copy on write snapshots
+        memory: "1.5Gi"
     redis-session:
-      image: redis:5-alpine
+      image: redis:6-alpine
       config:
         options: 
-          maxmemory: '1073742000'
+          # Handle many smaller keys
+          activedefrag: 'yes'
+          # 1Gi - 1024*1024*1024 bytes
+          maxmemory: '1073741824'
+          # Evict key that would expire soonest
           maxmemory-policy: volatile-ttl
-          save: 
-            - ['3600', '1']
-            - ['300', '100']
-            - ['60', '10000']
+          # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
+          # Redis < 7
+          # save: 
+          #   - ['3600', '1']
+          #   - ['300', '100']
+          #   - ['60', '10000']
+          # Redis >= 7
+          # save: 
+          #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
-        memory: "1024Mi"
+        # 1.5 * maxmemory to allow copy on write snapshots
+        memory: "1.5Gi"
     relay:
       enabled: true
       publish: false
@@ -141,10 +161,4 @@ attributes.default:
     qa:
       services: {}
     preview:
-      services:
-        redis:
-          resources:
-            memory: "64Mi"
-        redis-session:
-          resources:
-            memory: "64Mi"
+      services: {}

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -64,7 +64,7 @@ attributes.default:
       resources:
         memory: "1024Mi"
     redis:
-      image: redis:6-alpine
+      image: redis:7-alpine
       config:
         options:
           # Handle many smaller keys
@@ -75,20 +75,20 @@ attributes.default:
           maxmemory-policy: allkeys-lru
           # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
           # Redis < 7
-          # save: 
+          # save:
           #   - ['3600', '1']
           #   - ['300', '100']
           #   - ['60', '10000']
           # Redis >= 7
-          # save: 
+          # save:
           #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots
         memory: "256Mi"
     redis-session:
-      image: redis:6-alpine
+      image: redis:7-alpine
       config:
-        options: 
+        options:
           # Handle many smaller keys
           activedefrag: 'yes'
           # 170Mi - 170*1024*1024 bytes
@@ -97,12 +97,12 @@ attributes.default:
           maxmemory-policy: volatile-ttl
           # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
           # Redis < 7
-          # save: 
+          # save:
           #   - ['3600', '1']
           #   - ['300', '100']
           #   - ['60', '10000']
           # Redis >= 7
-          # save: 
+          # save:
           #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -69,8 +69,8 @@ attributes.default:
         options:
           # Handle many smaller keys
           activedefrag: 'yes'
-          # 1Gi - 1024*1024*1024 bytes
-          maxmemory: '1073741824'
+          # 170Mi - 170*1024*1024 bytes
+          maxmemory: '178257920'
           # Evict any least recently used key even if they don't have a TTL
           maxmemory-policy: allkeys-lru
           # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
@@ -84,15 +84,15 @@ attributes.default:
           #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots
-        memory: "1.5Gi"
+        memory: "256Mi"
     redis-session:
       image: redis:6-alpine
       config:
         options: 
           # Handle many smaller keys
           activedefrag: 'yes'
-          # 1Gi - 1024*1024*1024 bytes
-          maxmemory: '1073741824'
+          # 170Mi - 170*1024*1024 bytes
+          maxmemory: '178257920'
           # Evict key that would expire soonest
           maxmemory-policy: volatile-ttl
           # Save snapshots every X changes have happened within Y seconds (these are the defaults in redis.conf)
@@ -106,7 +106,7 @@ attributes.default:
           #   - ['3600', '1', '300', '100', '60', '10000']
       resources:
         # 1.5 * maxmemory to allow copy on write snapshots
-        memory: "1.5Gi"
+        memory: "256Mi"
     relay:
       enabled: true
       publish: false


### PR DESCRIPTION
* Upgrade to Redis 7.0+
* Reduce maxmemory to fit into the existing memory request of 256Mi. Note that existing servers that are over 170Mi of usage will need to manually delete keys to fit in, or adjust the maxmemory and memory request back up to the previous values.
* Remove the "preview" environment override for memory request as if the service is enabled with a 1Gi maxmemory, it won't fit in 64Mi
* Turn on activedefrag to better handle small keys