### PR TITLE
Replace podAntiAffinity with topologySpreadConstraints

### DIFF
--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -98,8 +98,14 @@ attributes:
   pipeline:
     base:
       global:
-        affinity:
-          selfAntiAffinityTopologyKey: ~
+        topologySpreadConstraints: []
+          # - topologyKey: topology.kubernetes.io/zone
+          #   # defaults:
+          #   # maxSkew: 1
+          #   # whenUnsatisfiable: ScheduleAnyway
+          # - topologyKey: kubernetes.io/hostname
+          #   maxSkew: 2
+          #   whenUnsatisfiable: DoNotSchedule
         prometheus:
           podMonitoring: false
         sealed_secrets:

--- a/helm/app/templates/_base_helper.tpl
+++ b/helm/app/templates/_base_helper.tpl
@@ -93,10 +93,8 @@ stringData:
 []
 {{- else }}
 {{- range $topologySpreadConstraints }}
-- labelSelector:
-    matchLabels:
-      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
-  {{- with (pick . "maxSkew" "topologyKey" "whenUnsatisfiable") }}
+- 
+  {{- with (pick . "labelSelector" "matchLabelKeys" "maxSkew" "topologyKey" "whenUnsatisfiable") }}
   {{- . | toYaml | nindent 2 }}
   {{- end }}
   {{- if not (hasKey . "maxSkew") }}
@@ -104,6 +102,11 @@ stringData:
   {{- end }}
   {{- if not (hasKey . "whenUnsatisfiable") }}
   whenUnsatisfiable: ScheduleAnyway
+  {{- end }}
+  {{- if not (or (hasKey . "labelSelector") (hasKey . "matchLabelKeys")) }}
+  labelSelector:
+    matchLabels:
+      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/app/templates/_base_helper.tpl
+++ b/helm/app/templates/_base_helper.tpl
@@ -106,7 +106,7 @@ stringData:
   {{- if not (or (hasKey . "labelSelector") (hasKey . "matchLabelKeys")) }}
   labelSelector:
     matchLabels:
-      app.service: {{ $.root.Values.resourcePrefix }}{{ $.serviceName }}
+      app.service: {{ print $.root.Release.Name "-" $.serviceName }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/app/templates/application/console/deployment.yaml
+++ b/helm/app/templates/application/console/deployment.yaml
@@ -25,7 +25,9 @@ spec:
         app.kubernetes.io/component: console
         app.service: {{ $.Release.Name }}-console
     spec:
-      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "console" "service" .) | nindent 8 }}
+      {{- with (pick . "affinity") }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
       containers:
       - env:
         {{- range $key, $value := (mergeOverwrite (dict) .environment .environment_dynamic) }}
@@ -73,6 +75,7 @@ spec:
       - name: {{ $.Release.Name }}-image-pull-config
 {{- end }}
       restartPolicy: Always
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "console" "service" .)) | nindent 8 }}
       enableServiceLinks: false
       volumes:
       {{- if not (eq "" (include "application.volumes.console" $)) }}

--- a/helm/app/templates/cronjobs.yaml
+++ b/helm/app/templates/cronjobs.yaml
@@ -92,6 +92,7 @@ spec:
           serviceAccountName: {{ tpl $service.serviceAccountName $ | quote }}
           {{- end }}
           {{- with .volumes }}
+          topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" $cronName "service" .)) | nindent 12 }}
           volumes:
             {{- range . }}
             - {{ tpl (toYaml (omit . "mountPath" "readOnly")) $ | nindent 12 }}

--- a/helm/app/templates/jobs.yaml
+++ b/helm/app/templates/jobs.yaml
@@ -82,6 +82,7 @@ spec:
       {{- if $service.serviceAccountName }}
       serviceAccountName: {{ tpl $service.serviceAccountName $ | quote }}
       {{- end }}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" $jobName "service" .)) | nindent 12 }}
       {{- with .volumes }}
       volumes:
         {{- range . }}

--- a/helm/app/templates/service/solr/statefulset.yaml
+++ b/helm/app/templates/service/solr/statefulset.yaml
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: solr
         app.service: {{ $.Release.Name }}-solr
     spec:
+      {{- with (pick . "affinity") }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
       securityContext:
         fsGroup: 8983
         runAsUser: 8983
@@ -69,6 +72,7 @@ spec:
       volumes:
       - name: {{ $.Release.Name }}-solr-data
         emptyDir: {}
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "solr" "service" .)) | nindent 8 }}
 {{- with $.Values.persistence.solr -}}
 {{- if .enabled }}
   volumeClaimTemplates:

--- a/helm/app/templates/service/varnish/statefulset.yaml
+++ b/helm/app/templates/service/varnish/statefulset.yaml
@@ -29,7 +29,9 @@ spec:
         app.kubernetes.io/component: varnish
         app.service: {{ $.Release.Name }}-varnish
     spec:
-      affinity: {{- include "pod.affinity" (dict "root" $ "serviceName" "console" "service" .) | nindent 8 }}
+      {{- with (pick . "affinity") }}
+      {{- . | toYaml | nindent 6 }}
+      {{- end }}
       containers:
       - name: varnish
         image: {{ .image | quote }}
@@ -52,6 +54,7 @@ spec:
         - name: varnish-cache
           mountPath: /var/lib/varnish
       restartPolicy: Always
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "varnish" "service" .)) | nindent 8 }}
       volumes:
       - name: varnish-configuration
         configMap:

--- a/helm/app/tests/values-pod-spread.yaml
+++ b/helm/app/tests/values-pod-spread.yaml
@@ -1,0 +1,11 @@
+global:
+  topologySpreadConstraints:
+    - topologyKey: topology.kubernetes.io/zone
+
+services:
+  varnish:
+    enabled: true
+    topologySpreadConstraints:
+      - topologyKey: topology.kubernetes.io/zone
+      - topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule


### PR DESCRIPTION
topologySpreadConstraints is specifically for this use-case, and spreads pods where possible equally between the topology

New configuration exposes support for setting multiple constraints, such as:

```yaml
global:
  topologySpreadConstraints:
   - topologyKey: topology.kubernetes.io/zone
   - topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: DoNotSchedule
```

Spread across zones and hosts, but don't allow scheduling on nodes that have 1 more of the app than other nodes (sort of like podAntiAffinity requiredDuringSchedulingIgnoredDuringExecution but allows overlapping and a higher skew).