### PR TITLE
Make Jenkins MY127WS_KEY optional

### DIFF
--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -4,7 +4,9 @@ pipeline {
     environment {
         COMPOSE_DOCKER_CLI_BUILD = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}
         DOCKER_BUILDKIT = {{ @('jenkins.docker.buildkit.enabled') ? '1' : '0' }}
+        {% if @('jenkins.credentials.my127ws_key') %}
         MY127WS_KEY = credentials('{{ @('jenkins.credentials.my127ws_key') }}')
+        {% endif %}
         MY127WS_ENV = "pipeline"
     }
     triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }


### PR DESCRIPTION
It will still render by default, but projects can unset it