### PR TITLE
Support ssh private key Jenkins credentials for chart publish

### DIFF
--- a/application/overlay/_twig/Jenkinsfile/publish.twig
+++ b/application/overlay/_twig/Jenkinsfile/publish.twig
@@ -5,6 +5,9 @@
 {% for key, value in @('pipeline.publish.environment') %}
                 {{ key }} = {{ value }}
 {% endfor %}
+{% if @('pipeline.publish.chart.git.ssh_credential_id') %}
+                WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY = credentials('{{ @('pipeline.publish.chart.git.ssh_credential_id') }}')
+{% endif %}
             }
 {% endif %}
             when {

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -19,10 +19,13 @@ command('app publish chart <release> <message>'):
     #!bash(workspace:/)|@
 
     run rm -rf build-artifacts-repository
-    echo "${SSH_PRIVATE_KEY}" | base64 -d > id_rsa
-    chmod 0600 id_rsa
 
-    export GIT_SSH_COMMAND='ssh -i ./id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
+    if [ -n "${SSH_PRIVATE_KEY:-}" ]; then
+      WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY="$(pwd)/id_ssh"
+      (umask 0077 && echo "${SSH_PRIVATE_KEY}" | base64 -d > "${WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY}")
+    fi
+
+    export GIT_SSH_COMMAND='ssh -i '"$(printf '%q' "$WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY")"' -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
 
     run git clone "$REPOSITORY" ./build-artifacts-repository
     run git -C ./build-artifacts-repository config user.email "${USER_EMAIL}"
@@ -30,7 +33,6 @@ command('app publish chart <release> <message>'):
     run mkdir -p $ARTIFACTS_PATH
     run rsync --exclude='*.twig' --exclude='_twig' --delete -a .my127ws/helm/app/ "${ARTIFACTS_PATH}/"
 
-    export GIT_SSH_COMMAND='ssh -i ../id_rsa -o "IdentitiesOnly yes" -F /dev/null -o StrictHostKeyChecking=no'
     run git -C ./build-artifacts-repository add .
     run "git -C ./build-artifacts-repository commit --allow-empty -m '${MESSAGE}'"
     run git -C ./build-artifacts-repository push origin -u HEAD


### PR DESCRIPTION
If a pipeline.publish.chart.ssh_credential_id is present, the private key will be put in a file with path in WS_APP_PUBLISH_CHART_SSH_PRIVATE_KEY variable.

Also use umask to set original ssh_private_key method file permissions on creation

This can also be used with Gitlab file CI variables without setting a ssh_credential_id or ssh_private_key.

This currently doesn't make use of the SSH passphrase variable that Jenkins can add, so only plain text private keys supported in the credential