### PR TITLE
Fix unnecessary ws destroy in harness testing

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -160,8 +160,11 @@ function teardown()
 
 function clean()
 {
-    if [ -d "$path_test" ]; then
+    if [ -d "${path_test}/.my127ws" ]; then
         (cd "$path_test" && ws destroy) || (docker ps -a && return 1)
+    fi
+
+    if [ -d "$path_test" ]; then
         rm -rf "$path_test"
     fi
 }


### PR DESCRIPTION
ws 0.3.0 introduced error exit codes, and `ws destroy` doesn't exist when .my127ws doesn't exist