### PR TITLE
Run weekly builds instead of nightly

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
-    triggers { cron(env.BRANCH_NAME ==~ /^(master|main|\d+\.\d+\.x)$/ ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME ==~ /^(master|main|\d+\.\d+\.x)$/ ? 'H H(2-6) * * 1' : '') }
     stages {
         stage('Quality Checks') {
             steps {

--- a/application/overlay/Jenkinsfile.twig
+++ b/application/overlay/Jenkinsfile.twig
@@ -9,7 +9,7 @@ pipeline {
         {% endif %}
         MY127WS_ENV = "pipeline"
     }
-    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(0-6) * * *' : '') }
+    triggers { cron(env.BRANCH_NAME == '{{ @('git.default_branch') }}' ? 'H H(2-6) * * 1' : '') }
     stages {
 {% include blocks ~ 'stages.twig' %}
     }


### PR DESCRIPTION
In an effort to reduce our electricity consumption and carbon usage, run builds once a week on a Monday morning rather than every morning.

2am to 6am seems best in terms of the renewable electricity mix based on https://electricityinfo.org/fuel-mix-last-24-hours/ and the forecast for London in https://electricityinfo.org/carbon-intensity-by-region/