### PR TITLE
Add support for providing configuration for multiple ingresses

### DIFF
--- a/.ci/sample-dynamic/workspace.yml
+++ b/.ci/sample-dynamic/workspace.yml
@@ -20,5 +20,5 @@ attributes:
 
 attribute('docker.port_forward.enabled'): false
 
-attribute('pipeline.base.ingress.annotations'):
+attribute('pipeline.base.ingresses.app.annotations'):
   example_nginx: test

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,7 @@ The following attributes were moved to a new key:
 * `helm.feature.sealed_secrets` -> `pipeline.base.global.sealed_secrets.enabled`
 * `pipeline.base.prometheus.podmonitoring` -> `pipeline.base.global.prometheus.podmonitoring`
 * `replicas.varnish` -> `pipeline.base.services.varnish.replicas` # however the value has been removed, as the default is 1
+* `pipeline.base.ingress` ->  `pipeline.base.ingresses.*` # ingresses aren't managed in this harness but the concept of multiple ingresses is required
 
 As such, they have also been moved in the helm values to their respective global and services configuration maps.
 

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,6 +1,6 @@
 appVersion: {{ @('app.version') | json_encode | raw }}
 
-ingress: {{ to_nice_yaml(@('pipeline.base.ingress'), 2, 2) | raw }}
+ingresses: {{ to_nice_yaml(@('pipeline.base.ingresses'), 2, 2) | raw }}
 
 global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) | raw }}
 


### PR DESCRIPTION
This harness doesn't provide any Ingress helm templates by default, but projects and downstream harnesses need to allow for it