### PR TITLE
Move mysql options into a config key for standardisation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,9 +7,11 @@
 The following attributes were moved to a new key:
 
 * `helm.feature.sealed_secrets` -> `pipeline.base.global.sealed_secrets.enabled`
-* `pipeline.base.prometheus.podmonitoring` -> `pipeline.base.global.prometheus.podmonitoring`
-* `replicas.varnish` -> `pipeline.base.services.varnish.replicas` # however the value has been removed, as the default is 1
 * `pipeline.base.ingress` ->  `pipeline.base.ingresses.*` # ingresses aren't managed in this harness but the concept of multiple ingresses is required
+* `pipeline.base.prometheus.podmonitoring` -> `pipeline.base.global.prometheus.podmonitoring`
+* `pipeline.base.services.mysql.options` -> `pipeline.base.services.mysql.config.options`
+* `replicas.varnish` -> `pipeline.base.services.varnish.replicas` # however the value has been removed, as the default is 1
+* `services.mysql.options` -> `services.mysql.config.options`
 
 As such, they have also been moved in the helm values to their respective global and services configuration maps.
 

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -1,4 +1,4 @@
-{% set command = @('services.mysql.options')
+{% set command = @('services.mysql.config.options')
   | filter(v => v is not empty)
   | map((value, var) => '--' ~ var ~ '=' ~ value)
   | reduce((carry, v) => carry|merge([v]), []) %}

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -30,10 +30,11 @@ attributes:
         memory: "512Mi"
     mysql:
       image: = @('mysql.image') ~ ':' ~ @('mysql.tag')
-      options:
-        default_authentication_plugin: "= (@('database.platform') == 'mysql' && @('database.platform_version') >= 8.0 && @('database.platform_version') < 10.0 ? 'mysql_native_password' : '')"
-        ignore-db-dir: "= (@('database.platform') == 'mysql' && @('database.platform_version') < 8.0 ? 'lost+found' : '')"
-        max_allowed_packet: 4M
+      config:
+        options:
+          default_authentication_plugin: "= (@('database.platform') == 'mysql' && @('database.platform_version') >= 8.0 && @('database.platform_version') < 10.0 ? 'mysql_native_password' : '')"
+          ignore-db-dir: "= (@('database.platform') == 'mysql' && @('database.platform_version') < 8.0 ? 'lost+found' : '')"
+          max_allowed_packet: 4M
       environment:
         MYSQL_DATABASE: = @('database.name')
         MYSQL_USER: = @('database.user')
@@ -118,7 +119,7 @@ attributes:
       configMaps: {}
       services:
         mysql:
-          options: = @('services.mysql.options')
+          config: = @('services.mysql.config')
         relay:
           enabled: false
     production:

--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -40,9 +40,9 @@ spec:
         image: {{ .image | quote }}
         imagePullPolicy: Always
         name: mysql
-        {{- if .options }}
+        {{- with .config.options }}
         args:
-        {{- range $var, $value := .options }}
+        {{- range $var, $value := . }}
         {{- if $value }}
         - {{ print "--" $var "=" $value | quote }}
         {{- end }}


### PR DESCRIPTION
helm charts generally use a config key for all their service configuration