### PR TITLE
Set docker-base attributes as lower precedence than harness.yml will use

### DIFF
--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -1,4 +1,4 @@
-attributes:
+attributes.default:
   services:
     console:
       enabled: true


### PR DESCRIPTION
Currently anything docker-base.yml sets, harness.yml can't override

This also affects project attributes if set in the project overlay