### PR TITLE
Allow the console to be disabled in local development

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,6 +33,8 @@ pipeline {
                 sh '.ci/test dynamic'
                 sh '.ci/test dynamic mutagen'
                 sh '.ci/test static-all-services'
+                sh '.ci/test static-console-disabled'
+                sh '.ci/test dynamic-console-disabled'
                 milestone(20)
             }
         }
@@ -51,8 +53,14 @@ pipeline {
                 stage('Mutagen') {
                     steps { sh '.ci/test dynamic mutagen' }
                 }
-                stage('Static All Services') {
+                stage('Static - All Services') {
                     steps { sh '.ci/test static-all-services' }
+                }
+                stage('Static - Console disabled') {
+                    steps { sh '.ci/test static-console-disabled' }
+                }
+                stage('Dynamic - Console disabled') {
+                    steps { sh '.ci/test dynamic-console-disabled' }
                 }
             }
         }

--- a/.ci/sample-dynamic-console-disabled/harnesses.json
+++ b/.ci/sample-dynamic-console-disabled/harnesses.json
@@ -1,0 +1,6 @@
+{
+  "inviqa/docker": {
+    "vx.x.x": {
+    }
+  }
+}

--- a/.ci/sample-dynamic-console-disabled/workspace.yml
+++ b/.ci/sample-dynamic-console-disabled/workspace.yml
@@ -1,0 +1,26 @@
+workspace('ci-docker-sample-dynamic'):
+  description: generated local workspace for ci-docker-sample.
+  harness: inviqa/docker
+
+harness.repository.source('name'): ./harnesses.json
+
+attributes:
+  services:
+    console:
+      enabled: false
+    chrome:
+      enabled: true
+    mysql:
+      enabled: true
+
+  aws:
+    repository: null
+    access_key_id: null
+    secret_access_key: null
+    s3:
+      bucket: null
+
+attribute('docker.port_forward.enabled'): false
+
+attribute('pipeline.base.ingresses.app.annotations'):
+  example_nginx: test

--- a/.ci/sample-static-console-disabled/harnesses.json
+++ b/.ci/sample-static-console-disabled/harnesses.json
@@ -1,0 +1,6 @@
+{
+  "inviqa/docker": {
+    "vx.x.x": {
+    }
+  }
+}

--- a/.ci/sample-static-console-disabled/workspace.yml
+++ b/.ci/sample-static-console-disabled/workspace.yml
@@ -1,0 +1,26 @@
+workspace('ci-docker-sample-static'):
+  description: generated local workspace for ci-docker-sample.
+  harness: inviqa/docker
+
+harness.repository.source('name'): ./harnesses.json
+
+attribute('app.build'): static
+
+attributes:
+  services:
+    console:
+      enabled: false
+    chrome:
+      enabled: true
+    mysql:
+      enabled: true
+
+  aws:
+    repository: null
+    access_key_id: null
+    secret_access_key: null
+    s3:
+      bucket: null
+
+attribute('mysql.tag'): 8
+attribute('database.platform_version'): 8.0

--- a/.ci/test
+++ b/.ci/test
@@ -67,9 +67,12 @@ function test_harness_acceptance()
     prepare_environment
     if (cd "${path_test}" && docker compose config --services) | grep -Fxe console; then
       install_console
+      run_project_quality_tests
+      install_environment
+    else
+      install_environment
+      run_project_quality_tests
     fi
-    run_project_quality_tests
-    install_environment
     check_environment_started "$mode"
     run_project_acceptance_tests
     restart_environment

--- a/.ci/test
+++ b/.ci/test
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-set -e
-set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
 export path_test=".ci/tmp-test"
 
@@ -62,7 +64,10 @@ function test_harness_acceptance()
     local mode="$1"
     local sync="$2"
 
-    install_console
+    prepare_environment
+    if (cd "${path_test}" && docker compose config --services) | grep -Fxe console; then
+      install_console
+    fi
     run_project_quality_tests
     install_environment
     check_environment_started "$mode"

--- a/harness/attributes/common.yml
+++ b/harness/attributes/common.yml
@@ -27,7 +27,7 @@ attributes.default:
       buildkit:
         enabled: true
     tests:
-      isolated: true
+      isolated: = @('services.console.enabled')
       use_global_services: false
 
   pipeline:

--- a/harness/scripts/enable.sh.twig
+++ b/harness/scripts/enable.sh.twig
@@ -3,6 +3,13 @@
 # shellcheck disable=SC2206
 COMPOSE_BIN=($COMPOSE_BIN)
 
+service_configured()
+{
+    "${COMPOSE_BIN[@]}" config --services | grep --quiet -Fxe "$1"
+}
+
+CONSOLE_CONFIGURED="$(service_configured console && echo "true" || echo "false")"
+
 console_enabled()
 {
     if [ "$APP_BUILD" = dynamic ]; then
@@ -34,7 +41,7 @@ enable_all()
     if [ "$IS_BUILT" = no ]; then
         if [ "$HAS_FLAG" = no ]; then
             # remove all services, keeping console if considered built
-            if console_enabled; then
+            if [ "$CONSOLE_CONFIGURED" == true ] && console_enabled; then
                 # shellcheck disable=SC2143
                 if [ -n "$("${COMPOSE_BIN[@]}" ps --services | grep -v -Fxe console)" ]; then
                     passthru "${COMPOSE_BIN[*]}  ps --services | grep -v -Fxe console | xargs ${COMPOSE_BIN[*]} rm --force --stop --"
@@ -44,7 +51,7 @@ enable_all()
             fi
         fi
 
-        if [ "$HAS_ASSETS" = yes ]; then
+        if [ "$CONSOLE_CONFIGURED" == true ] && [ "$HAS_ASSETS" = yes ]; then
             ws assets download
         fi
 
@@ -59,11 +66,18 @@ enable_all()
         fi
 
         passthru "${COMPOSE_BIN[@]}" up -d
-        passthru "${COMPOSE_BIN[@]}" exec -T -u build console app welcome
+        if [ "$CONSOLE_CONFIGURED" == true ]; then
+            passthru "${COMPOSE_BIN[@]}" exec -T -u build console app welcome
+        fi
     fi
 }
 
 enable_console() {
+    if [ "$CONSOLE_CONFIGURED" == false ]; then
+        echo "error: console is not configured to be enabled" >&2
+        exit 1
+    fi
+
     if [ "$APP_BUILD" = dynamic ] && console_enabled && [ -z "$("${COMPOSE_BIN[@]}" ps --quiet --all console)" ]; then
         rm .my127ws/.flag-console-built
     fi
@@ -105,7 +119,9 @@ dynamic()
 {
     ws external-images pull
 
-    dynamic_console
+    if [ "$CONSOLE_CONFIGURED" == true ]; then
+        dynamic_console
+    fi
 
     passthru "ws app build"
 }
@@ -128,11 +144,13 @@ initial_start()
     # Bring up all services apart from cron
     passthru "${COMPOSE_BIN[*]} config --services | grep -v -Fxe cron | xargs ${COMPOSE_BIN[*]} up -d"
 
-    passthru "${COMPOSE_BIN[@]}" exec -T -u build console app init
+    if [ "$CONSOLE_CONFIGURED" == true ]; then
+        passthru "${COMPOSE_BIN[@]}" exec -T -u build console app init
+    fi
 
-    {% if @('services.cron.enabled') %}
-    passthru "${COMPOSE_BIN[@]}" up -d cron
-    {% endif %}
+    if service_configured cron; then
+        passthru "${COMPOSE_BIN[@]}" up -d cron
+    fi
 }
 
 "enable_$1"


### PR DESCRIPTION
While not really recommended, as it's currently used for ws create and harness upgrades, some projects wont need it for day to day use, and is extra baggage in those cases.

It's already able to be disabled in deployments, but in that scenario it needs to be enabled locally.