### PR TITLE
Create a shared template for pvcs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -12,6 +12,7 @@ The following attributes were moved to a new key:
 * `pipeline.base.services.mysql.options` -> `pipeline.base.services.mysql.config.options`
 * `replicas.varnish` -> `pipeline.base.services.varnish.replicas` # however the value has been removed, as the default is 1
 * `services.mysql.options` -> `services.mysql.config.options`
+* `persistence.solr` -> `persistence.solr-data`
 
 As such, they have also been moved in the helm values to their respective global and services configuration maps.
 

--- a/harness/attributes/common-base.yml
+++ b/harness/attributes/common-base.yml
@@ -256,6 +256,7 @@ attributes.default:
 
     elasticsearch:
       enabled: true
+      claimName: "{{ $.Release.Name }}-elasticsearch-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 2Gi
     mongodb:
@@ -264,22 +265,27 @@ attributes.default:
       size: 1Gi
     mysql:
       enabled: true
+      claimName: "{{ $.Release.Name }}-mysql-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 4Gi
     rabbitmq:
       enabled: true
+      claimName: "{{ $.Release.Name }}-rabbitmq-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 2Gi
     postgres:
       enabled: true
+      claimName: "{{ $.Release.Name }}-postgres-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 4Gi
     redis:
       enabled: false
+      claimName: "{{ $.Release.Name }}-redis-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 2Gi
     redis-session:
       enabled: true
+      claimName: "{{ $.Release.Name }}-redis-session-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 2Gi
     solr-data:

--- a/harness/attributes/common-base.yml
+++ b/harness/attributes/common-base.yml
@@ -282,7 +282,7 @@ attributes.default:
       enabled: true
       accessMode: ReadWriteOnce
       size: 2Gi
-    solr:
+    solr-data:
       enabled: true
       accessMode: ReadWriteOnce
       size: 1Gi

--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -1,0 +1,65 @@
+{{- define "resource.persistentVolumeClaim" }}
+{{- if .root.Values.persistence.enabled }}
+{{- with index .root.Values.persistence .name }}
+{{- if .enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ tpl (.claimName | default "") $.root | default (print $.root.Release.Name "-" $.name) | quote }}
+  labels:
+    {{- include "chart.labels" $.root | nindent 4 }}
+    app.kubernetes.io/component: {{ $.serviceName | default $.name | quote }}
+    app.service: {{ print $.root.Release.Name "-" ($.serviceName | default $.name) | quote}}
+  {{- with (pick . "annotations") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- with (pick . "selector" "volumeMode" "volumeName") }}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "statefulSet.volumeClaimTemplate" }}
+{{- with index .root.Values.persistence .name }}
+metadata:
+  name: {{ tpl (.claimName | default "") $.root | default (print $.root.Release.Name "-" $.name) | quote }}
+  labels:
+    {{- include "chart.selectors" $.root | nindent 4 }}
+    app.kubernetes.io/component: {{ $.serviceName | default $.name | quote }}
+    app.service: {{ print $.root.Release.Name "-" ($.serviceName | default $.name) | quote}}
+  {{- with (pick . "annotations") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- with (pick . "selector" "volumeMode" "volumeName") }}
+  {{- . | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/app/templates/service/elasticsearch/pvc.yaml
+++ b/helm/app/templates/service/elasticsearch/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.elasticsearch -}}
-{{- if and .enabled ($.Values.services | dig "elasticsearch" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-elasticsearch-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: elasticsearch
-    app.service: {{ $.Release.Name }}-elasticsearch
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "elasticsearch" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "elasticsearch") }}
 {{- end }}

--- a/helm/app/templates/service/mongodb/pvc.yaml
+++ b/helm/app/templates/service/mongodb/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.mongodb -}}
-{{- if and .enabled ($.Values.services | dig "mongodb" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-mongodb
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: mongodb
-    app.service: {{ $.Release.Name }}-mongodb
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "mongodb" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "mongodb") }}
 {{- end }}

--- a/helm/app/templates/service/mysql/pvc.yaml
+++ b/helm/app/templates/service/mysql/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.mysql -}}
-{{- if and .enabled ($.Values.services | dig "mysql" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-mysql-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: mysql
-    app.service: {{ $.Release.Name }}-mysql
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "mysql" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "mysql") }}
 {{- end }}

--- a/helm/app/templates/service/postgres/pvc.yaml
+++ b/helm/app/templates/service/postgres/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.postgres -}}
-{{- if and .enabled ($.Values.services | dig "postgres" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-postgres-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: postgres
-    app.service: {{ $.Release.Name }}-postgres
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "postgres" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "postgres") }}
 {{- end }}

--- a/helm/app/templates/service/rabbitmq/pvc.yaml
+++ b/helm/app/templates/service/rabbitmq/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.rabbitmq -}}
-{{- if and .enabled ($.Values.services | dig "rabbitmq" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-rabbitmq-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: rabbitmq
-    app.service: {{ $.Release.Name }}-rabbitmq
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "rabbitmq" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "rabbitmq") }}
 {{- end }}

--- a/helm/app/templates/service/redis-session/pvc.yaml
+++ b/helm/app/templates/service/redis-session/pvc.yaml
@@ -1,32 +1,3 @@
-{{- with index .Values.persistence "redis-session" -}}
-{{ if and .enabled (index $.Values.services "redis-session" "enabled") -}}
-
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-redis-session-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: redis-session
-    app.service: {{ $.Release.Name }}-redis-session
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "redis-session" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "redis-session") }}
 {{- end }}

--- a/helm/app/templates/service/redis/pvc.yaml
+++ b/helm/app/templates/service/redis/pvc.yaml
@@ -1,31 +1,3 @@
-{{- with .Values.persistence.redis -}}
-{{- if and .enabled ($.Values.services | dig "redis" "enabled" false) }}
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: {{ $.Release.Name }}-redis-pv-claim
-  labels:
-    {{- include "chart.labels" $ | nindent 4 }}
-    app.kubernetes.io/component: redis
-    app.service: {{ $.Release.Name }}-redis
-spec:
-  accessModes:
-    - {{ .accessMode | quote }}
-  resources:
-    requests:
-      storage: {{ .size | quote }}
-{{- if .storageClass }}
-{{- if (eq "-" .storageClass) }}
-  storageClassName: ""
-{{- else }}
-  storageClassName: {{ .storageClass | quote }}
-{{- end }}
-{{- end }}
-{{- if .selector }}
-  selector:
-  {{- .selector | toYaml | nindent 4 }}
-{{- end }}
-
-{{- end }}
-
+{{- if .Values.services | dig "redis" "enabled" false }}
+{{- include "resource.persistentVolumeClaim" (dict "root" $ "name" "redis") }}
 {{- end }}

--- a/helm/app/templates/service/solr/statefulset.yaml
+++ b/helm/app/templates/service/solr/statefulset.yaml
@@ -76,28 +76,7 @@ spec:
 {{- with $.Values.persistence.solr -}}
 {{- if .enabled }}
   volumeClaimTemplates:
-    - metadata:
-        name: {{ $.Release.Name }}-solr-data
-        labels:
-          {{- include "chart.selectors" $ | nindent 10 }}
-          app.kubernetes.io/component: solr
-          app.service: {{ $.Release.Name }}-solr
-      spec:
-        accessModes:
-          - {{ .accessMode | quote }}
-        resources:
-          requests:
-            storage: {{ .size | quote }}
-        {{- if .storageClass }}
-        {{- if (eq "-" .storageClass) }}
-        storageClassName: ""
-        {{- else }}
-        storageClassName: {{ .storageClass | quote }}
-        {{- end }}
-        {{- end }}
-        {{- with (pick . "selector" "volumeMode" "volumeName") }}
-        {{- . | toYaml | nindent 8 }}
-        {{- end }}
+    - {{ include "statefulset.volumeClaimTemplate" (dict "root" $ "name" "solr-data" "serviceName" "solr") | nindent 8 }}
 {{- end }}
 {{- end }}
 

--- a/helm/app/tests/values-pvcs.yaml
+++ b/helm/app/tests/values-pvcs.yaml
@@ -1,0 +1,2 @@
+persistence:
+  enabled: true


### PR DESCRIPTION
So they don't need to individually be maintained.

volumeClaimTemplates using another template for less changes to labels (chart.selectors instead of chart.labels) and no kind/apiVersion as standard, and also to allow it to not be changed if the resource.persistentVolumeClaim template is changed