### PR TITLE
Use the older utitlization spec for HPAs on v2beta2 prior to k8s 1.23

### DIFF
--- a/helm/app/templates/horizontal-pod-autoscaler.yaml
+++ b/helm/app/templates/horizontal-pod-autoscaler.yaml
@@ -30,17 +30,25 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
     {{- end }}
     {{- with $autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.23-0" $.Capabilities.KubeVersion.Version }}
         target:
           type: Utilization
           averageUtilization: {{ . }}
+        {{- else }}
+        targetAverageUtilization: {{ . }}
+        {{- end }}
     {{- end }}
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
Unclear if needed, but other charts do this