### PR TITLE
Make redis configurable

### DIFF
--- a/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -1,8 +1,16 @@
+{% set command = @('services.redis-session.config.options')
+  | filter(v => v is not empty)
+  | map(
+    (value, var) => (value is iterable ? value : [value]) 
+      | map((value) => ['--' ~ var] | merge(value is iterable ? value : [value]) )
+      | reduce((carry, v) => carry|merge(v), [])
+    )
+  | reduce((carry, v) => carry|merge(v), ['redis-server'])
+%}
 services:
   redis-session:
     image: {{ @('services.redis-session.image') }}
-    # 1GB; evict key that would expire soonest
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy volatile-ttl --save 3600 1 --save 300 100 --save 60 10000
+    command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
       - traefik.enable=false
     networks:

--- a/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/_twig/docker-compose.yml/service/redis.yml.twig
@@ -1,8 +1,16 @@
+{% set command = @('services.redis-session.config.options')
+  | filter(v => v is not empty)
+  | map(
+    (value, var) => (value is iterable ? value : [value]) 
+      | map((value) => ['--' ~ var] | merge(value is iterable ? value : [value]) )
+      | reduce((carry, v) => carry|merge(v), [])
+    )
+  | reduce((carry, v) => carry|merge(v), ['redis-server'])
+%}
 services:
   redis:
     image: {{ @('services.redis.image')  }}
-    # 1GB; evict any least recently used key even if they don't have a TTL
-    command: redis-server --maxmemory 1073742000 --maxmemory-policy allkeys-lru --save 3600 1 --save 300 100 --save 60 10000
+    command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
       - traefik.enable=false
     networks:

--- a/harness/attributes/docker-base.yml
+++ b/harness/attributes/docker-base.yml
@@ -65,10 +65,26 @@ attributes.default:
         memory: "1024Mi"
     redis:
       image: redis:5-alpine
+      config:
+        options: 
+          maxmemory: '1073742000'
+          maxmemory-policy: allkeys-lru
+          save: 
+            - ['3600', '1']
+            - ['300', '100']
+            - ['60', '10000']
       resources:
         memory: "256Mi"
     redis-session:
       image: redis:5-alpine
+      config:
+        options: 
+          maxmemory: '1073742000'
+          maxmemory-policy: volatile-ttl
+          save: 
+            - ['3600', '1']
+            - ['300', '100']
+            - ['60', '10000']
       resources:
         memory: "1024Mi"
     relay:
@@ -118,8 +134,6 @@ attributes.default:
           scope: = @('helm.sealed_secrets.scope')
       configMaps: {}
       services:
-        mysql:
-          config: = @('services.mysql.config')
         relay:
           enabled: false
     production:

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -77,6 +77,7 @@ function('filter_local_services', [services]): |
     $filteredService = [];
     foreach ($service as $key => $value) {
       switch ($key) {
+        case 'config':
         case 'enabled':
         case 'environment':
         case 'environment_dynamic':

--- a/helm/app/templates/service/redis-session/deployment.yaml
+++ b/helm/app/templates/service/redis-session/deployment.yaml
@@ -27,24 +27,19 @@ spec:
         app.service: {{ $.Release.Name }}-redis-session
     spec:
       containers:
-      - args:
+      - name: redis-session
+        args:
         - redis-server
-        - --maxmemory
-        - "1073742000"
-        - --maxmemory-policy
-        - volatile-ttl
-        - --save
-        - "3600"
-        - "1"
-        - --save
-        - "300"
-        - "100"
-        - --save
-        - "60"
-        - "10000"
+        {{- range $var, $value := .config.options }}
+        {{- range $optValue := kindIs "slice" $value | ternary $value (list $value) }}
+        - {{ print "--" $var | quote }}
+        {{- range $arrayValue := kindIs "slice" $optValue | ternary $optValue (list $optValue) }}
+        - {{ $arrayValue | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         image: {{ .image | quote }}
         imagePullPolicy: Always
-        name: redis-session
         ports:
         - containerPort: 6379
         resources:

--- a/helm/app/templates/service/redis/deployment.yaml
+++ b/helm/app/templates/service/redis/deployment.yaml
@@ -28,24 +28,19 @@ spec:
         app.service: {{ $.Release.Name }}-redis
     spec:
       containers:
-      - args:
+      - name: redis
+        args:
         - redis-server
-        - --maxmemory
-        - "1073742000"
-        - --maxmemory-policy
-        - allkeys-lru
-        - --save
-        - "3600"
-        - "1"
-        - --save
-        - "300"
-        - "100"
-        - --save
-        - "60"
-        - "10000"
+        {{- range $var, $value := .config.options }}
+        {{- range $optValue := kindIs "slice" $value | ternary $value (list $value) }}
+        - {{ print "--" $var | quote }}
+        {{- range $arrayValue := kindIs "slice" $optValue | ternary $optValue (list $optValue) }}
+        - {{ $arrayValue | quote }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         image: {{ .image | quote }}
         imagePullPolicy: Always
-        name: redis
         ports:
         - containerPort: 6379
         resources:


### PR DESCRIPTION
The default memory resources is still too low, but just implementing the bare minimum first without any changes in effect

Also make services.*.config available by default from local to pipeline