### PR TITLE
Add support for local traefik proxy v2 using newer format labels

### DIFF
--- a/_twig/docker-compose.yml/service/chrome.yml.twig
+++ b/_twig/docker-compose.yml/service/chrome.yml.twig
@@ -7,6 +7,7 @@ services:
     image: quay.io/inviqa_images/chromium:latest
 {% endif %}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       - private

--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -19,6 +19,7 @@ services:
     image: {{ @('services.console.image') }}
 {% endif %}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     environment: {{ to_nice_yaml(deep_merge([
         @('services.console.environment'),

--- a/_twig/docker-compose.yml/service/elasticsearch.yml.twig
+++ b/_twig/docker-compose.yml/service/elasticsearch.yml.twig
@@ -2,6 +2,7 @@ services:
   elasticsearch:
     image: {{ @('services.elasticsearch.image') }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     environment:
       ES_JAVA_OPTS: -Xms512m -Xmx512m

--- a/_twig/docker-compose.yml/service/memcached.yml.twig
+++ b/_twig/docker-compose.yml/service/memcached.yml.twig
@@ -2,6 +2,7 @@ services:
   memcached:
     image: {{ @('services.memcached.image') }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       - private

--- a/_twig/docker-compose.yml/service/mongodb.yml.twig
+++ b/_twig/docker-compose.yml/service/mongodb.yml.twig
@@ -7,6 +7,7 @@ services:
         @('services.mongodb.environment_secrets')
       ]), 2, 6) | raw }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       - private

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -6,6 +6,7 @@ services:
   mysql:
     image: {{ @('services.mysql.image') }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     command: {{ to_nice_yaml(command, 2, 6) }}
     environment: {{ to_nice_yaml(deep_merge([

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -2,6 +2,7 @@ services:
   postgres:
     image: {{ @('services.postgres.image') }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     environment: {{ to_nice_yaml(deep_merge([
         @('services.postgres.environment'),

--- a/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -10,9 +10,15 @@ services:
       - private
       - shared
     labels:
-      - traefik.backend={{ @('rabbitmq.host') }}-{{ @('workspace.name') }}
+      - co.elastic.logs/module=rabbitmq
+      - co.elastic.metrics/module=rabbitmq
+      # Traefik 1, deprecated
+      - traefik.backend={{ @('workspace.name') }}-rabbitmq
       - traefik.frontend.rule=Host:{{ @('rabbitmq.external_host') }}
       - traefik.docker.network=my127ws
       - traefik.port={{ @('rabbitmq.api_port') }}
-      - co.elastic.logs/module=rabbitmq
-      - co.elastic.metrics/module=rabbitmq
+      # Traefik 2
+      - traefik.enable=true
+      # - traefik.docker.network=my127ws
+      - traefik.http.routers.{{ @('workspace.name') }}-rabbitmq.rule=Host(`{{ @('rabbitmq.external_host') }}`)
+      - traefik.http.services.{{ @('workspace.name') }}-rabbitmq.loadbalancer.server.port={{ @('rabbitmq.api_port') }}

--- a/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -12,6 +12,7 @@ services:
     image: {{ @('services.redis-session.image') }}
     command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       - private

--- a/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/_twig/docker-compose.yml/service/redis.yml.twig
@@ -12,6 +12,7 @@ services:
     image: {{ @('services.redis.image')  }}
     command: {{ to_nice_yaml(command, 2, 6) }}
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       - private

--- a/_twig/docker-compose.yml/service/relay.yml.twig
+++ b/_twig/docker-compose.yml/service/relay.yml.twig
@@ -2,6 +2,7 @@ services:
   relay:
     build: .my127ws/docker/image/relay
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     networks:
       private:

--- a/_twig/docker-compose.yml/service/solr.yml.twig
+++ b/_twig/docker-compose.yml/service/solr.yml.twig
@@ -12,10 +12,16 @@ services:
         @('services.solr.environment_secrets')
       ]), 2, 6) | raw }}
     labels:
-      - traefik.backend=solr-{{ @('workspace.name') }}
-      - traefik.frontend.rule=Host:solr-{{ @('hostname') }}
+      # Traefik 1, deprecated
+      - traefik.backend={{ @('workspace.name') }}-solr
+      - traefik.frontend.rule=Host:solr-{{  @('hostname') }}
       - traefik.docker.network=my127ws
       - traefik.port=8983
+      # Traefik 2
+      - traefik.enable=true
+      # - traefik.docker.network=my127ws
+      - traefik.http.routers.{{ @('workspace.name') }}-solr.rule=Host(`solr-{{  @('hostname') }}`)
+      - traefik.http.services.{{ @('workspace.name') }}-solr.loadbalancer.server.port=8983
     volumes:
       - solr_data:{{ @('services.solr.environment.SOLR_VOLUME_DIR') }}
     networks:

--- a/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -1,14 +1,21 @@
 {% if @('services.varnish.enabled') %}
 {% set hostnames = [@('hostname')] %}
 {% set hostnames = hostnames|merge(@('hostname_aliases')|map(alias => "#{alias}." ~ @('domain'))) %}
+{% set traefikRules = hostnames|map(hostname => "Host(`" ~ hostname ~ "`)") %}
 services:
   varnish:
     image: {{ @('services.varnish.image') }}
     labels:
+      # Traefik 1, deprecated
       - traefik.backend={{ @('workspace.name') }}
       - traefik.frontend.rule=Host:{{ hostnames|join(',') }}
       - traefik.docker.network=my127ws
       - traefik.port=80
+      # Traefik 2
+      - traefik.enable=true
+      # - traefik.docker.network=my127ws
+      - traefik.http.routers.{{ @('workspace.name') }}-varnish.rule={{ traefikRules | join(' || ') }}
+      - traefik.http.services.{{ @('workspace.name') }}-varnish.loadbalancer.server.port=80
     environment: {{ to_nice_yaml(deep_merge([
       @('services.varnish.environment'),
       @('services.varnish.environment_dynamic'),
@@ -38,6 +45,7 @@ services:
     build:
       context: .my127ws/docker/image/tls-offload/
     labels:
+      # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     links:
       - varnish:varnish


### PR DESCRIPTION
Also the v2 proxy will be set to disabled services by default rather than needing a traefik.enable=false for all services not exposed