### PR TITLE
Fix missing ability to reflect PVC claimName or default in service deployments

### DIFF
--- a/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       - name: elasticsearch-data
 {{- if $.Values.persistence.elasticsearch.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-elasticsearch-pv-claim
+          claimName: {{ tpl $.Values.persistence.elasticsearch.claimName $ | default (print $.Release.Name "-elasticsearch") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       - name: elasticsearch-data
 {{- if $.Values.persistence.elasticsearch.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.elasticsearch.claimName $ | default (print $.Release.Name "-elasticsearch") | quote }}
+          claimName: {{ tpl ($.Values.persistence.elasticsearch.claimName | default "") $ | default (print $.Release.Name "-elasticsearch") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/mongodb/deployment.yaml
+++ b/helm/app/templates/service/mongodb/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: data-db
 {{- if $.Values.persistence.mongodb.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.mongodb.claimName $ | default (print $.Release.Name "-mongodb") | quote }}
+          claimName: {{ tpl ($.Values.persistence.mongodb.claimName | default "") $ | default (print $.Release.Name "-mongodb") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/mongodb/deployment.yaml
+++ b/helm/app/templates/service/mongodb/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: data-db
 {{- if $.Values.persistence.mongodb.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-mongodb
+          claimName: {{ tpl $.Values.persistence.mongodb.claimName $ | default (print $.Release.Name "-mongodb") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -68,7 +68,7 @@ spec:
       - name: mysql-data
 {{- if $.Values.persistence.mysql.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-mysql-pv-claim
+          claimName: {{ tpl $.Values.persistence.mysql.claimName $ | default (print $.Release.Name "-mysql") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/mysql/deployment.yaml
+++ b/helm/app/templates/service/mysql/deployment.yaml
@@ -68,7 +68,7 @@ spec:
       - name: mysql-data
 {{- if $.Values.persistence.mysql.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.mysql.claimName $ | default (print $.Release.Name "-mysql") | quote }}
+          claimName: {{ tpl ($.Values.persistence.mysql.claimName | default "") $ | default (print $.Release.Name "-mysql") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/postgres/deployment.yaml
+++ b/helm/app/templates/service/postgres/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: postgres-data
 {{- if $.Values.persistence.postgres.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.postgres.claimName $ | default (print $.Release.Name "-postgres") | quote }}
+          claimName: {{ tpl ($.Values.persistence.postgres.claimName | default "") $ | default (print $.Release.Name "-postgres") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/postgres/deployment.yaml
+++ b/helm/app/templates/service/postgres/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: postgres-data
 {{- if $.Values.persistence.postgres.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-postgres-pv-claim
+          claimName: {{ tpl $.Values.persistence.postgres.claimName $ | default (print $.Release.Name "-postgres") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       - name: rabbitmq-data
 {{- if $.Values.persistence.rabbitmq.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.rabbitmq.claimName $ | default (print $.Release.Name "-rabbitmq") | quote }}
+          claimName: {{ tpl ($.Values.persistence.rabbitmq.claimName | default "") $ | default (print $.Release.Name "-rabbitmq") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/rabbitmq/deployment.yaml
+++ b/helm/app/templates/service/rabbitmq/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       - name: rabbitmq-data
 {{- if $.Values.persistence.rabbitmq.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-rabbitmq-pv-claim
+          claimName: {{ tpl $.Values.persistence.rabbitmq.claimName $ | default (print $.Release.Name "-rabbitmq") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/redis-session/deployment.yaml
+++ b/helm/app/templates/service/redis-session/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: redis-data
 {{- if index $.Values.persistence "redis-session" "enabled" }}
         persistentVolumeClaim:
-          claimName: {{ tpl (index $.Values.persistence "redis-session" "claimName") $ | default (print $.Release.Name "-redis-session") | quote }}
+          claimName: {{ tpl (index $.Values.persistence "redis-session" "claimName" | default "") $ | default (print $.Release.Name "-redis-session") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/redis-session/deployment.yaml
+++ b/helm/app/templates/service/redis-session/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       - name: redis-data
 {{- if index $.Values.persistence "redis-session" "enabled" }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-redis-session-pv-claim
+          claimName: {{ tpl (index $.Values.persistence "redis-session" "claimName") $ | default (print $.Release.Name "-redis-session") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/redis/deployment.yaml
+++ b/helm/app/templates/service/redis/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       - name: redis-data
 {{- if $.Values.persistence.redis.enabled }}
         persistentVolumeClaim:
-          claimName: {{ $.Release.Name }}-redis-pv-claim
+          claimName: {{ tpl $.Values.persistence.redis.claimName $ | default (print $.Release.Name "-redis") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}

--- a/helm/app/templates/service/redis/deployment.yaml
+++ b/helm/app/templates/service/redis/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       - name: redis-data
 {{- if $.Values.persistence.redis.enabled }}
         persistentVolumeClaim:
-          claimName: {{ tpl $.Values.persistence.redis.claimName $ | default (print $.Release.Name "-redis") | quote }}
+          claimName: {{ tpl ($.Values.persistence.redis.claimName | default "") $ | default (print $.Release.Name "-redis") | quote }}
 {{- else }}
         emptyDir: {}
 {{- end }}


### PR DESCRIPTION
Where a non-standard {release}-{service-ish} pvc name already used, the claimName is already supplied explicitly in the attributes