### PR TITLE
Provide hint to the elasticsearch pvc the elasticsearch user id

### DIFF
--- a/helm/app/templates/service/elasticsearch/deployment.yaml
+++ b/helm/app/templates/service/elasticsearch/deployment.yaml
@@ -28,6 +28,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+        runAsUser: 1000
       containers:
       - env:
         - name: ES_JAVA_OPTS


### PR DESCRIPTION
Apparently elasticsearch is more picky with the volume mount permissions.

Based on https://github.com/inviqa/harness-base-php/pull/669