### PR TITLE
Ensure startup commands convert sidekick run to passthru

### DIFF
--- a/docker/image/console/root/entrypoint.sh.twig
+++ b/docker/image/console/root/entrypoint.sh.twig
@@ -20,5 +20,6 @@ bootstrap
 if [ "${1:-}" == "sleep" ]; then
     exec /sbin/tini -- bash -c "$(printf "%q " "$@")"
 else
+    export SIDEKICK_VERBOSE=yes
     exec /sbin/tini -- "$@"
 fi

--- a/docker/image/console/root/usr/lib/sidekick.sh
+++ b/docker/image/console/root/usr/lib/sidekick.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERBOSE="no"
+VERBOSE="${SIDEKICK_VERBOSE:-no}"
 
 RUN_CWD=""
 


### PR DESCRIPTION
The /tmp/my127ws-std* files created during startup, when on failure, are not available