### PR TITLE
Switch over to docker compose v2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,18 @@
 
 ## Upgrading from 0.2.x to 0.3.x
 
+### `docker-compose` command now `docker compose`
+
+In line with the preferred way to run Docker Compose v2, the harness will now use the binary from it's Docker plugin architecture.
+
+This means all `docker-compose` commands are replaced with `docker compose`. For Docker Desktop users there is no difference, however Linux users may need to [install the Compose plugin](https://docs.docker.com/compose/install/linux/).
+
+If you really would like to continue using the old command, you can set in your `~/.config/my127/workspace/config.yml`:
+
+```yaml
+attribute('docker.compose.bin'): docker-compose
+```
+
 ### Preview environments are now only created if the PR has a `publish-preview` label
 
 In order to reduce waste in docker images and mess of cluster repositories, PRs will only be published (if preview enabled) when the PR has a `publish-preview` label.

--- a/application/skeleton/README.md.twig
+++ b/application/skeleton/README.md.twig
@@ -19,7 +19,7 @@ Please follow the below steps to get started, if you encounter any issues instal
 - A working Docker setup
   - On macOS, use [Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/install/).
   - On Linux, add the official Docker repository described under the "Server" section on [Install Docker Engine](https://docs.docker.com/engine/install/) and install the "docker-ce" package.
-    You will also need to have a recent [docker-compose](https://docs.docker.com/compose/install/) version - at least `1.26.0`.
+    You will also need to have a recent [docker compose](https://docs.docker.com/compose/install/) version - at least `2.20.3`.
 
 #### Setup
 

--- a/harness/attributes/common-base.yml
+++ b/harness/attributes/common-base.yml
@@ -135,7 +135,7 @@ attributes.default:
     buildkit:
       enabled: true
     compose:
-      bin: 'docker-compose'
+      bin: 'docker compose'
       host_volume_options: "= ':' ~ (@('delegated-volumes') ? 'delegated' : 'cached')"
     # If using gitops helm chart repositories, it's recommended to put this configuration
     # in the values.yml in there now instead of project application repositories


### PR DESCRIPTION
This expects docker compose v2 to be installed as a docker plugin rather than directly running it's binary.