### PR TITLE
Allow an external PVC to be used by services by stopping creation

### DIFF
--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -1,7 +1,7 @@
 {{- define "resource.persistentVolumeClaim" }}
 {{- if .root.Values.persistence.enabled }}
 {{- with index .root.Values.persistence .name }}
-{{- if .enabled }}
+{{- if . | dig "create" .enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/helm/app/tests/values-pvcs.yaml
+++ b/helm/app/tests/values-pvcs.yaml
@@ -1,2 +1,7 @@
 persistence:
   enabled: true
+  mysql:
+    create: false
+  postgres:
+    enabled: false
+    create: true


### PR DESCRIPTION
For example:

* .enabled = true , create = false - for when a PVC is managed externally

If .create is unset then it's only the .enabled boolean checked

Statefulsets volumeClaimTemplates won't use this as they always maintain their own PVCs