### PR TITLE
Support podmonitors for pods with multiple containers

### DIFF
--- a/helm/app/templates/podmonitors.yaml
+++ b/helm/app/templates/podmonitors.yaml
@@ -1,6 +1,10 @@
 {{- range $serviceName := (.Values.services | keys) -}}
 {{- with (include "service.resolved" (dict "root" $ "service_name" $serviceName) | fromYaml) }}
-{{- if and (not (hasPrefix "_" $serviceName)) $.Values.global.prometheus.podMonitoring (. | dig "metricsEnabled" true) .metricsEndpoints }}
+{{- if and (not (hasPrefix "_" $serviceName)) $.Values.global.prometheus.podMonitoring .enabled .metricsEnabled }}
+{{- $endpointServices := kindIs "slice" .containers  | ternary (list) (list .) }}
+{{- range .containers }}
+{{- $endpointServices = append $endpointServices (include "service.resolved" (dict "root" $ "service_name" .) | fromYaml)}}
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -15,7 +19,11 @@ spec:
     matchLabels:
       app.service: {{ print $.Release.Name "-" $serviceName | quote }}
   podMetricsEndpoints:
-    {{- .metricsEndpoints | toYaml | nindent 6 }}
+  {{- range $endpointServices }}
+  {{- if and (. | dig "enabled" true) .metricsEndpoints }}
+    {{- .metricsEndpoints | toYaml | nindent 4 }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/app/tests/values-podmonitors.yaml
+++ b/helm/app/tests/values-podmonitors.yaml
@@ -1,0 +1,38 @@
+global:
+  prometheus:
+    podMonitoring: true
+
+services:
+  single-container:
+    enabled: true
+    metricsEnabled: true
+    metricsEndpoints:
+      - port: http-monitoring
+  
+  single-container-disabled:
+    enabled: false
+    metricsEnabled: true
+    metricsEndpoints:
+      - port: http-monitoring
+
+  multi-container-a:
+    metricsEndpoints:
+      - port: http-monitoring
+  
+  multi-container-b:
+    metricsEndpoints:
+      - path: /another-metrics
+        port: another-http-port
+  
+  multi-container-c:
+    enabled: false
+    metricsEndpoints:
+      - port: http-monitoring
+  
+  multi-container-pod:
+    enabled: true
+    containers:
+      - multi-container-a
+      - multi-container-b
+      - multi-container-c
+    metricsEnabled: true


### PR DESCRIPTION
A consequence of this for service.*.enabled is that while pod enabled is a hard true check, container enabled is a soft check which is only disabled if explicit enabled: false

metricsEnabled is only checked in the pod service, however metricsEnabled should not be set (or set to false) for container services to avoid them also getting a podmonitor that has no pod