### PR TITLE
Stop errors if solr service is not in helm values

### DIFF
--- a/helm/app/templates/service/solr/headless-service.yaml
+++ b/helm/app/templates/service/solr/headless-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.services.solr.enabled }}
+{{- if .Values.services | dig "solr" "enabled" false }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/app/templates/service/solr/service.yaml
+++ b/helm/app/templates/service/solr/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.services.solr.enabled }}
+{{- if .Values.services | dig "solr" "enabled" false }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Technically not a bug as it's always there, but helps with testing helm without creating a test environment