### PR TITLE
Fix services losing their PVCs with default settings

### DIFF
--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -31,7 +31,6 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end }}
 
 {{- define "statefulSet.volumeClaimTemplate" }}
 {{- with index .root.Values.persistence .name }}
@@ -59,5 +58,6 @@ spec:
 {{- end }}
 {{- with (pick . "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -1,5 +1,4 @@
 {{- define "resource.persistentVolumeClaim" }}
-{{- if .root.Values.persistence.enabled }}
 {{- with index .root.Values.persistence .name }}
 {{- if .enabled }}
 kind: PersistentVolumeClaim
@@ -60,6 +59,5 @@ spec:
 {{- end }}
 {{- with (pick . "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
persistence.enabled was never previously checked for them, so were enabled by default until #79.

While this assumes no downstream harnesses use this template for application PVCs until the 0.3.0 release, which instead enable persistence.enabled by default #112