### PR TITLE
Rename job helm test job resources to avoid downstream duplication

### DIFF
--- a/helm/app/tests/values-jobs.yaml
+++ b/helm/app/tests/values-jobs.yaml
@@ -7,7 +7,7 @@ services:
   some-jobs:
     enabled: true
     jobs:
-      app-init:
+      example-app-init:
         annotations:
           helm.sh/hook: "pre-install"
           helm.sh/hook-delete-policy: "before-hook-creation"
@@ -16,7 +16,7 @@ services:
         command:
           - app
           - init
-      app-migrate:
+      example-app-migrate:
         annotations:
           helm.sh/hook: "pre-upgrade"
           helm.sh/hook-delete-policy: "before-hook-creation"


### PR DESCRIPTION
Downstream php harness uses these as static templates rather than dynamic job configuration, so results in an error during the pvc test when same name resources.

dynamic jobs don't include the name of the service they were in, whether that was a right decision or not.