### PR TITLE
Add opensearch as a docker service

### DIFF
--- a/.ci/sample-static-all-services/workspace.yml
+++ b/.ci/sample-static-all-services/workspace.yml
@@ -18,6 +18,8 @@ attributes:
       enabled: true
     mysql:
       enabled: true
+    opensearch:
+      enabled: true
     postgres:
       enabled: true
     rabbitmq:

--- a/_twig/docker-compose.yml/service/opensearch.yml.twig
+++ b/_twig/docker-compose.yml/service/opensearch.yml.twig
@@ -1,0 +1,18 @@
+services:
+  opensearch:
+    image: {{ @('services.opensearch.image') }}
+    labels:
+      # deprecated, a later workspace release will disable by default
+      - traefik.enable=false
+    environment: {{ to_nice_yaml(deep_merge([
+        @('services.opensearch.environment'),
+        @('services.opensearch.environment_dynamic'),
+        @('services.opensearch.environment_secrets')
+      ]), 2, 6) | raw }}
+    networks:
+      - private
+{% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}
+    ports:
+      - "127.0.0.1:0:9200"
+      - "127.0.0.1:0:9300"
+{% endif %}

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -274,6 +274,10 @@ attributes.default:
       claimName: "{{ $.Release.Name }}-mysql-pv-claim" # legacy naming
       accessMode: ReadWriteOnce
       size: 4Gi
+    opensearch-data:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 2Gi
     rabbitmq:
       enabled: true
       claimName: "{{ $.Release.Name }}-rabbitmq-pv-claim" # legacy naming

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -276,6 +276,7 @@ attributes.default:
       size: 4Gi
     opensearch-data:
       enabled: true
+      claimName: data # as a volumeClaimTemplate this becomes data-{release name}-opensearch-{pod number}
       accessMode: ReadWriteOnce
       size: 2Gi
     rabbitmq:

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -46,6 +46,15 @@ attributes.default:
         MYSQL_ROOT_PASSWORD: = @('database.root_pass')
       resources:
         memory: "512Mi"
+    opensearch:
+      image: = @('services.opensearch.repository') ~ ':' ~ @('services.opensearch.tag')
+      repository: opensearchproject/opensearch
+      tag: '2.9.0'
+      environment:
+        OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
+        discovery.type: single-node
+      resources:
+        memory: "1024Mi"
     postgres:
       image: postgres:9.6
       environment:

--- a/helm/app/templates/service/opensearch/headless-service.yaml
+++ b/helm/app/templates/service/opensearch/headless-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.services | dig "opensearch" "enabled" false }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+    app.service: {{ .Release.Name }}-opensearch
+  name: {{ .Release.Name }}-opensearch-headless
+spec:
+  clusterIP: None
+  ports:
+  - name: http
+    port: 6200
+    targetPort: http
+  selector:
+    app.service: {{ .Release.Name }}-opensearch
+{{- end }}

--- a/helm/app/templates/service/opensearch/service.yaml
+++ b/helm/app/templates/service/opensearch/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.services | dig "opensearch" "enabled" false }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+    app.service: {{ .Release.Name }}-opensearch
+  name: {{ .Release.Name }}-opensearch
+spec:
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+  selector:
+    app.service: {{ .Release.Name }}-opensearch
+{{- end }}

--- a/helm/app/templates/service/opensearch/statefulset.yaml
+++ b/helm/app/templates/service/opensearch/statefulset.yaml
@@ -1,0 +1,72 @@
+{{- with .Values.services.opensearch -}}
+{{- if .enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $.Release.Name }}-opensearch
+  annotations:
+    argocd.argoproj.io/sync-wave: "4"
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: opensearch
+    app.service: {{ $.Release.Name }}-opensearch
+spec:
+  {{- with (pick . "replicas" "revisionHistoryLimit" "podManagementPolicy") }}
+  {{- . | toYaml | nindent 2 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.service: {{ $.Release.Name }}-opensearch
+  serviceName: {{ $.Release.Name }}-opensearch-headless
+  template:
+    metadata:
+      labels:
+        {{- include "chart.selectors" $ | nindent 8 }}
+        app.kubernetes.io/component: opensearch
+        app.service: {{ $.Release.Name }}-opensearch
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      containers:
+      - name: opensearch
+        {{- include "service.environment" (dict "root" $ "serviceName" "opensearch" "service" .) | nindent 8 }}
+        image: {{ .image | quote }}
+        imagePullPolicy: Always
+        ports:
+        - name: http
+          containerPort: 9200
+        resources:
+          limits:
+            memory: {{ .resources.memory }}
+          requests:
+            {{- with (.resources | dig "cpu" "request" nil) }}
+            cpu: {{ . }}
+            {{- end }}
+            memory: {{ .resources.memory }}
+        startupProbe:
+          tcpSocket:
+            port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 30
+        readinessProbe:
+          tcpSocket:
+            port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+        volumeMounts:
+        - name: {{ include "persistence.claimName" (dict "root" $ "name" "opensearch-data") | quote }}
+          mountPath: /usr/share/opensearch/data
+      restartPolicy: Always
+      topologySpreadConstraints: {{- (include "pod.topologySpreadConstraints" (dict "root" $ "serviceName" "opensearch" "service" .)) | nindent 8 }}
+      volumes:
+      - name: {{ include "persistence.claimName" (dict "root" $ "name" "opensearch-data") | quote }}
+        emptyDir: {}
+{{- if and $.Values.persistence.enabled $.Values.persistence.opensearch.enabled }}
+  volumeClaimTemplates:
+    - {{ include "statefulSet.volumeClaimTemplate" (dict "root" $ "name" "opensearch-data" "serviceName" "opensearch") | nindent 8 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/app/templates/service/opensearch/statefulset.yaml
+++ b/helm/app/templates/service/opensearch/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
       volumes:
       - name: {{ include "persistence.claimName" (dict "root" $ "name" "opensearch-data") | quote }}
         emptyDir: {}
-{{- if and $.Values.persistence.enabled $.Values.persistence.opensearch.enabled }}
+{{- if and $.Values.persistence.enabled (index $.Values.persistence "opensearch-data" "enabled") }}
   volumeClaimTemplates:
     - {{ include "statefulSet.volumeClaimTemplate" (dict "root" $ "name" "opensearch-data" "serviceName" "opensearch") | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
As elasticsearch and opensearch diverge, we'll need opensearch for reproducing AWS's Opensearch service.

The helm template and supplied configuration isn't clustering capable as is, though uses a statefulset