### PR TITLE
Update postgres to 15

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,12 @@ If you really would like to continue using the old command, you can set in your 
 attribute('docker.compose.bin'): docker-compose
 ```
 
+### Services updated to latest versions
+
+Postgres 9.6 has been EOL since 2021-11-11, so the default Postgres version has been updated to 15.
+
+It's possible if you are using postgres service that some internal data structures need to be upgraded to work with the new version. If functionality doesn't work after upgrade, then you will need to upgrade the database or for a short term update the tag back to 9.6 to plan it separately.
+
 ### Kubernetes persistence enabled by default
 
 Since it makes more sense for persistence to be enabled for environments, and previously backend service persistence was also enabled by default, persistence of application volumes is now also enabled by default.

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -178,7 +178,7 @@ attributes.default:
     platform: mysql
     platform_version: >
       = @('database.platform') == 'mysql' ? '8.0'
-      : @('database.platform') == 'postgres' ? '16'
+      : @('database.platform') == 'postgres' ? '15'
       : null
     host: mysql
     port: 3306

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -178,7 +178,7 @@ attributes.default:
     platform: mysql
     platform_version: >
       = @('database.platform') == 'mysql' ? '8.0'
-      : @('database.platform') == 'postgres' ? '9.6'
+      : @('database.platform') == 'postgres' ? '16'
       : null
     host: mysql
     port: 3306

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -56,7 +56,7 @@ attributes.default:
       resources:
         memory: "1024Mi"
     postgres:
-      image: postgres:16
+      image: postgres:15
       environment:
         POSTGRES_DB: = @('database.name')
         POSTGRES_USER: = @('database.user')

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -56,7 +56,7 @@ attributes.default:
       resources:
         memory: "1024Mi"
     postgres:
-      image: postgres:9.6
+      image: postgres:16
       environment:
         POSTGRES_DB: = @('database.name')
         POSTGRES_USER: = @('database.user')


### PR DESCRIPTION
9.6 has been EOL since 11th November 2021, and not offered on managed db services.

15 final release planned for 2027

Versioning x.y release lifetime changed to x lifetime since 10, so though new features will be introduced, x.y (15.4) has too short a timeline, so follow x (15)