### PR TITLE
Follow version 2 tag for opensearch

### DIFF
--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -49,7 +49,7 @@ attributes.default:
     opensearch:
       image: = @('services.opensearch.repository') ~ ':' ~ @('services.opensearch.tag')
       repository: opensearchproject/opensearch
-      tag: '2.9.0'
+      tag: '2'
       environment:
         OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
         discovery.type: single-node


### PR DESCRIPTION
Release schedule for 2.x.y (even 2.x but no tag) opensearch is too frequent to manage as a default, but projects can chose to pin if needed