### PR TITLE
Update mongodb to 5.0

### DIFF
--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -24,7 +24,7 @@ attributes.default:
     memcached:
       image: memcached:1-alpine
     mongodb:
-      image: mongo:4.4
+      image: mongo:7.0
       environment:
         MONGO_INITDB_ROOT_USERNAME: admin
       environment_secrets:

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -24,7 +24,7 @@ attributes.default:
     memcached:
       image: memcached:1-alpine
     mongodb:
-      image: mongo:7.0
+      image: mongo:5.0
       environment:
         MONGO_INITDB_ROOT_USERNAME: admin
       environment_secrets:


### PR DESCRIPTION
Following https://www.mongodb.com/docs/manual/reference/versioning/, x.0 is supported for a year, x.1+ no support

5.0 becomes EOL 01 Oct 2024