### PR TITLE
Obsolete older workspace versions with undetectable version

### DIFF
--- a/harness.yml
+++ b/harness.yml
@@ -6,7 +6,6 @@ harness('inviqa/docker'):
       - proxy
     confd:
       - harness:/
-    workspace: '~0.3.1'
 ---
 import:
   - harness/config/*.yml

--- a/harness.yml
+++ b/harness.yml
@@ -6,7 +6,7 @@ harness('inviqa/docker'):
       - proxy
     confd:
       - harness:/
-    workspace: '~0.3'
+    workspace: '~0.3.1'
 ---
 import:
   - harness/config/*.yml

--- a/harness.yml
+++ b/harness.yml
@@ -6,6 +6,7 @@ harness('inviqa/docker'):
       - proxy
     confd:
       - harness:/
+    workspace: '~0.3'
 ---
 import:
   - harness/config/*.yml

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -19,7 +19,7 @@ command('enable'):
 command('version check'): |
     #!php
     if (!method_exists(my127\Workspace\Application::class, 'getVersion')) {
-      echo "Workspace versions prior to 0.3.0 not supported by this harness version\n";
+      echo "Workspace versions prior to 0.3.1 not supported by this harness version\n";
       echo "Please upgrade Workspace to continue\n";
       exit(1);
     }

--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -16,6 +16,14 @@ command('enable'):
     set -- all
     source .my127ws/harness/scripts/enable.sh
 
+command('version check'): |
+    #!php
+    if (!method_exists(my127\Workspace\Application::class, 'getVersion')) {
+      echo "Workspace versions prior to 0.3.0 not supported by this harness version\n";
+      echo "Please upgrade Workspace to continue\n";
+      exit(1);
+    }
+
 command('enable console'):
   env:
     USE_MUTAGEN:          = boolToString(@('host.os') == 'darwin' and @('mutagen'))

--- a/harness/config/events.yml
+++ b/harness/config/events.yml
@@ -1,6 +1,7 @@
 
 after('harness.install'): |
   #!bash
+  ws version check
   ws enable
 
 after('harness.refresh'):


### PR DESCRIPTION
Obsoletes all previous harness versions before 0.3.1

This is a check that would be removed sometime in the future, as will instead use a workspace version constraint instead, which workspace will act on.