### PR TITLE
Allow a new PVC to be populated from another data source

### DIFF
--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -26,7 +26,7 @@ spec:
   storageClassName: {{ .storageClass | quote }}
 {{- end }}
 {{- end }}
-{{- with (pick . "dataSourceRef" "selector" "volumeMode" "volumeName") }}
+{{- with (pick . "dataSource" "dataSourceRef" "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -58,7 +58,7 @@ spec:
   storageClassName: {{ .storageClass | quote }}
 {{- end }}
 {{- end }}
-{{- with (pick . "dataSourceRef" "selector" "volumeMode" "volumeName") }}
+{{- with (pick . "dataSource" "dataSourceRef" "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/helm/app/templates/_storage.tpl
+++ b/helm/app/templates/_storage.tpl
@@ -26,7 +26,7 @@ spec:
   storageClassName: {{ .storageClass | quote }}
 {{- end }}
 {{- end }}
-{{- with (pick . "selector" "volumeMode" "volumeName") }}
+{{- with (pick . "dataSourceRef" "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}
@@ -58,7 +58,7 @@ spec:
   storageClassName: {{ .storageClass | quote }}
 {{- end }}
 {{- end }}
-{{- with (pick . "selector" "volumeMode" "volumeName") }}
+{{- with (pick . "dataSourceRef" "selector" "volumeMode" "volumeName") }}
   {{- . | toYaml | nindent 2 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This is only supported by storage managed by CSI Drivers that support it, so e.g. AWS EBS, DO volume storage drivers, and csi-driver-nfs, but not nfs-server-provisioner/nfs-subdir-external-provisioner or AWS EFS

It can restore a PVC from another PVC or VolumeSnapshot of the same CSI driver (or other if CSI Driver has other CRDs when dataSourceRef is stable)

```
persistence:
  app-data:
    accessMode: ReadWriteOnce
    dataSource:
      name: myapp-app-data-2023-09-25
      kind: VolumeSnapshot
      apiGroup: snapshot.storage.k8s.io
```
VolumeSnapshot resource creation not in scope of harness.
