### PR TITLE
Update ws app publish chart to support multiple clusters

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,9 @@ The following attributes were moved to a new key:
 
 * `elasticsearch.image` -> `services.elasticsearch.repository`
 * `elasticsearch.tag` -> `services.elasticsearch.tag`
+* `pipeline.publish.chart.git.ssh_credential_id` -> `pipeline.clusters.*.git.ssh_credential_id`
+* `pipeline.publish.chart.git.ssh_private_key` -> `pipeline.clusters.*.git.ssh_private_key`
+* `pipeline.publish.chart.git.repository` -> `pipeline.clusters.*.git.repository`
 
 ### Major updates of mongodb and postgres due to EOL
 
@@ -56,6 +59,32 @@ attribute('docker.compose.bin'): docker-compose
 Postgres 9.6 has been EOL since 2021-11-11, so the default Postgres version has been updated to 15.
 
 It's possible if you are using postgres service that some internal data structures need to be upgraded to work with the new version. If functionality doesn't work after upgrade, then you will need to upgrade the database or for a short term update the tag back to 9.6 to plan it separately.
+
+### `ws app publish chart <cluster> <branch> <commit message>` and `pipeline.clusters`
+
+Some projects need to deploy to multiple Kubernetes clusters, so multiple cluster repositories need to be defined.
+
+As due to this, the process for adding the first cluster repository has changed:
+
+```diff
+ pipeline:
++  clusters:
++    mycluster:
++      git:
++        ssh_credential_id: ...
++        repository: ...
+   publish:
+     chart:
+       enabled: true
++      default_cluster: mycluster
+-      git:
+-        ssh_credential_id: ...
+-        repository: ....
+```
+
+Additional clusters can be added to pipeline.clusters, however currently still you need to define Jenkinsfile stages for these to fit in your deployment pipeline.
+
+The `ws app publish chart` command has now an additional first argument of the cluster name, in order to publish to the specified cluster.
 
 ### Kubernetes persistence enabled by default
 

--- a/application/overlay/_twig/Jenkinsfile/publish.twig
+++ b/application/overlay/_twig/Jenkinsfile/publish.twig
@@ -1,8 +1,9 @@
 {% if @('pipeline.publish.enabled') %}
         stage('Publish') {
 {% set env = @('pipeline.publish.environment') %}
+{% set cluster = @('pipeline.publish.chart.default_cluster') %}
 {% set docker_registry_credential_id = @('docker.registry.credential_id') %}
-{% set ssh_credential_id = @('pipeline.publish.chart.git.ssh_credential_id') %}
+{% set ssh_credential_id = @('pipeline.clusters.' ~ cluster ~ '.git.ssh_credential_id') %}
 {% if env or docker_registry_credential_id or ssh_credential_id %}
             environment {
 {% for key, value in env %}
@@ -41,8 +42,8 @@
                 milestone(50)
                 sh 'ws app publish'
 {% if @('pipeline.publish.chart.enabled') %}
-                lock(resource: '{{ @('pipeline.publish.chart.git.repository') }}', inversePrecedence: true) {
-                    sh 'ws app publish chart "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
+                lock(resource: '{{ @('pipeline.clusters.' ~ cluster ~ '.git.repository') }}', inversePrecedence: true) {
+                    sh 'ws app publish chart "{{ cluster }}" "${GIT_BRANCH}" "{{ @('workspace.name') }} build artifact ${GIT_COMMIT}"'
                 }
 {% endif %}
             }

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -56,6 +56,16 @@ attributes.default:
     base:
       persistence: = @('persistence')
       hostname:  = @('pipeline.preview.hostname')
+    clusters: {}
+      # pipeline:
+      #   git:
+      #     # A SSH Username with private key Jenkins credential id.
+      #     # Preferred over ssh_private_key to store credentials local development doesn't need
+      #     ssh_credential_id: ~
+      #     # private key with write access to the repository
+      #     ssh_private_key: = @('pipeline.publish.chart.git.key')
+      #     # eg. git@github.com:organisation/project.git
+      #     repository: ~
     publish:
       enabled: false
       services: = publishable_services(@('services'))
@@ -69,17 +79,12 @@ attributes.default:
       # to the given git repository.
       chart:
         enabled: false
+        # The cluster name from pipeline.clusters that the chart should be published to automatically after merge or as preview release
+        default_cluster: ~ # e.g pipeline
         git:
-          # A SSH Username with private key Jenkins credential id.
-          # Preferred over ssh_private_key to store credentials local development doesn't need
-          ssh_credential_id: ~
-          # private key with write access to the repository
-          ssh_private_key: = @('pipeline.publish.chart.git.key')
-          # eg. git@github.com:organisation/project.git
-          repository: ~
           # path within the repository to place the chart, no leading or trailing slashes
           # note: an additional directory with the branch name will be created
-          path: = 'build-artifacts/' ~ @('workspace.name')
+          path: = 'build-artifacts/' ~ @('workspace.name') 
           # sets the git user.name and user.email before pushing the commit
           user_name: Jenkins
           email: name@example.com

--- a/harness/config/pipeline.yml
+++ b/harness/config/pipeline.yml
@@ -9,10 +9,10 @@ command('app publish'):
     passthru $COMPOSE_BIN push @('pipeline.publish.services')
     run docker logout '@('docker.registry.url')'
 
-command('app publish chart <release> <message>'):
+command('app publish chart <cluster> <release> <message>'):
   env:
-    SSH_PRIVATE_KEY:    = @('pipeline.publish.chart.git.ssh_private_key')
-    REPOSITORY: = @('pipeline.publish.chart.git.repository')
+    SSH_PRIVATE_KEY:    = @('pipeline.clusters.' ~ input.argument('cluster') ~ '.git.ssh_private_key')
+    REPOSITORY: = @('pipeline.clusters.' ~ input.argument('cluster') ~ '.git.repository')
     ARTIFACTS_PATH:  = "./build-artifacts-repository/" ~ @('pipeline.publish.chart.git.path') ~ "/" ~ input.argument('release')
     MESSAGE:    = input.argument('message')
     GIT_USER_NAME: = @('pipeline.publish.chart.git.user_name')


### PR DESCRIPTION
Also moves cluster git repository definitions to `pipeline.clusters` and requires a `pipeline.publish.chart.default_cluster` value set for the cluster name

This doesn't lay out any Jenkinsfile stages for additional clusters currently.