### PR TITLE
Remove unneeded raw twig filters

### DIFF
--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -25,6 +25,6 @@ services:
         @('services.console.environment'),
         @('services.console.environment_dynamic'),
         @('services.console.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private

--- a/_twig/docker-compose.yml/service/elasticsearch.yml.twig
+++ b/_twig/docker-compose.yml/service/elasticsearch.yml.twig
@@ -8,7 +8,7 @@ services:
         @('services.elasticsearch.environment'),
         @('services.elasticsearch.environment_dynamic'),
         @('services.elasticsearch.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/lighthouse.yml.twig
+++ b/_twig/docker-compose.yml/service/lighthouse.yml.twig
@@ -4,7 +4,7 @@ services:
     entrypoint: "/usr/bin/dumb-init --"
     command: "/bin/true"
     environment:
-      TARGET_URL: "{{ @('lighthouse.target.url') | raw }}"
+      TARGET_URL: "{{ @('lighthouse.target.url') }}"
       OUTPUT_RESULTS: ~
 {% if @('app.build') == 'dynamic' %}
     volumes:

--- a/_twig/docker-compose.yml/service/mongodb.yml.twig
+++ b/_twig/docker-compose.yml/service/mongodb.yml.twig
@@ -5,7 +5,7 @@ services:
         @('services.mongodb.environment'),
         @('services.mongodb.environment_dynamic'),
         @('services.mongodb.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/_twig/docker-compose.yml/service/mysql.yml.twig
+++ b/_twig/docker-compose.yml/service/mysql.yml.twig
@@ -13,7 +13,7 @@ services:
         @('services.mysql.environment'),
         @('services.mysql.environment_dynamic'),
         @('services.mysql.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/opensearch.yml.twig
+++ b/_twig/docker-compose.yml/service/opensearch.yml.twig
@@ -8,7 +8,7 @@ services:
         @('services.opensearch.environment'),
         @('services.opensearch.environment_dynamic'),
         @('services.opensearch.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/postgres.yml.twig
+++ b/_twig/docker-compose.yml/service/postgres.yml.twig
@@ -8,7 +8,7 @@ services:
         @('services.postgres.environment'),
         @('services.postgres.environment_dynamic'),
         @('services.postgres.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private
 {% if @('app.build') != 'static' and @('docker.port_forward.enabled') %}

--- a/_twig/docker-compose.yml/service/rabbitmq.yml.twig
+++ b/_twig/docker-compose.yml/service/rabbitmq.yml.twig
@@ -5,7 +5,7 @@ services:
         @('services.rabbitmq.environment'),
         @('services.rabbitmq.environment_dynamic'),
         @('services.rabbitmq.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     networks:
       - private
       - shared

--- a/_twig/docker-compose.yml/service/redis-session.yml.twig
+++ b/_twig/docker-compose.yml/service/redis-session.yml.twig
@@ -15,7 +15,7 @@ services:
         @('services.redis-session.environment'),
         @('services.redis-session.environment_dynamic'),
         @('services.redis-session.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/_twig/docker-compose.yml/service/redis.yml.twig
+++ b/_twig/docker-compose.yml/service/redis.yml.twig
@@ -15,7 +15,7 @@ services:
         @('services.redis.environment'),
         @('services.redis.environment_dynamic'),
         @('services.redis.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false

--- a/_twig/docker-compose.yml/service/solr.yml.twig
+++ b/_twig/docker-compose.yml/service/solr.yml.twig
@@ -10,7 +10,7 @@ services:
         @('services.solr.environment'),
         @('services.solr.environment_dynamic'),
         @('services.solr.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     labels:
       # Traefik 1, deprecated
       - traefik.backend={{ @('workspace.name') }}-solr

--- a/_twig/docker-compose.yml/service/varnish.yml.twig
+++ b/_twig/docker-compose.yml/service/varnish.yml.twig
@@ -20,7 +20,7 @@ services:
       @('services.varnish.environment'),
       @('services.varnish.environment_dynamic'),
       @('services.varnish.environment_secrets')
-      ]), 2, 6) | raw }}
+      ]), 2, 6) }}
     links:
       - {{ @('varnish.target_service') }}:{{ @('varnish.target_service') }}
     volumes:

--- a/docker/image/console/root/entrypoint.sh.twig
+++ b/docker/image/console/root/entrypoint.sh.twig
@@ -4,7 +4,7 @@ run_steps()
 {
     # run any command required to be executed at docker startup
     {% for step in @('console.entrypoint.steps') -%}
-    {{ step|raw }}
+    {{ step }}
     {% else -%}
     :
     {% endfor %}

--- a/docker/image/console/root/usr/lib/task/build.sh.twig
+++ b/docker/image/console/root/usr/lib/task/build.sh.twig
@@ -14,13 +14,13 @@ function task_build()
 
     cd /app
 
-    if {{ @('task.build.when')|raw }}; then 
+    if {{ @('task.build.when') }}; then 
         :
     else
         return 0;
     fi
 
     {% for step in @('task.build.steps') -%}
-    {{ step|raw }}
+    {{ step }}
     {% endfor %}
 }

--- a/docker/image/console/root/usr/lib/task/database/import.sh.twig
+++ b/docker/image/console/root/usr/lib/task/database/import.sh.twig
@@ -3,7 +3,7 @@
 function task_database_import()
 {
   {% for step in @('database.import.steps') -%}
-  {{ step|raw }}
+  {{ step }}
   {% else %}
   :
   {% endfor %}

--- a/docker/image/console/root/usr/lib/task/init.sh.twig
+++ b/docker/image/console/root/usr/lib/task/init.sh.twig
@@ -9,7 +9,7 @@ function task_init()
         task assets:apply
 
         {% for step in @('backend.init.steps') -%}
-        {{ step|raw }}
+        {{ step }}
         {% endfor %}
 
         task welcome

--- a/docker/image/console/root/usr/lib/task/install.sh.twig
+++ b/docker/image/console/root/usr/lib/task/install.sh.twig
@@ -5,7 +5,7 @@ function task_install()
     task database:available
 
     {% for step in @('backend.install.steps') -%}
-    {{ step|raw }}
+    {{ step }}
     {% endfor %}
 
 }

--- a/docker/image/console/root/usr/lib/task/migrate.sh.twig
+++ b/docker/image/console/root/usr/lib/task/migrate.sh.twig
@@ -5,6 +5,6 @@ function task_migrate()
     task database:available
 
     {% for step in @('backend.migrate.steps') -%}
-    {{ step|raw }}
+    {{ step }}
     {% endfor %}
 }

--- a/helm/app/values-preview.yaml.twig
+++ b/helm/app/values-preview.yaml.twig
@@ -1,9 +1,9 @@
 {% if @('pipeline.preview.global') %}
-global: {{ to_nice_yaml(@('pipeline.preview.global'), 2, 2) | raw }}  
+global: {{ to_nice_yaml(@('pipeline.preview.global'), 2, 2) }}  
 {% endif %}
 {% if @('pipeline.preview.services') %}
-services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) | raw }}  
+services: {{ to_nice_yaml(@('pipeline.preview.services'), 2, 2) }}  
 {% endif %}
 {% if @('pipeline.preview.persistence') %}
-persistence: {{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.preview.persistence'), 2, 2) }}
 {% endif %}

--- a/helm/app/values-production.yaml.twig
+++ b/helm/app/values-production.yaml.twig
@@ -1,9 +1,9 @@
 {% if @('pipeline.production.global') %}
-global: {{ to_nice_yaml(@('pipeline.production.global'), 2, 2) | raw }}  
+global: {{ to_nice_yaml(@('pipeline.production.global'), 2, 2) }}  
 {% endif %}
 {% if @('pipeline.production.services') %}
-services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 2) | raw }}  
+services: {{ to_nice_yaml(@('pipeline.production.services'), 2, 2) }}  
 {% endif %}
 {% if @('pipeline.production.persistence') %}
-persistence: {{ to_nice_yaml(@('pipeline.production.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.production.persistence'), 2, 2) }}
 {% endif %}

--- a/helm/app/values.yaml.twig
+++ b/helm/app/values.yaml.twig
@@ -1,19 +1,19 @@
-appVersion: {{ @('app.version') | json_encode | raw }}
+appVersion: {{ @('app.version') | json_encode }}
 
-ingresses: {{ to_nice_yaml(@('pipeline.base.ingresses'), 2, 2) | raw }}
+ingresses: {{ to_nice_yaml(@('pipeline.base.ingresses'), 2, 2) }}
 
-global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) | raw }}
+global: {{ to_nice_yaml(@('pipeline.base.global'), 2, 2) }}
 
 docker:
-  image_pull_config: {{ @('docker.image_pull_config') | raw }}
+  image_pull_config: {{ @('docker.image_pull_config') }}
 
 services: {{ to_nice_yaml(deep_merge([
     filter_local_services(@('services')),
     @('pipeline.base.services')
-  ]), 2, 2) | raw }}
+  ]), 2, 2) }}
 
-configMaps: {{ to_nice_yaml(@('pipeline.base.configMaps'), 2, 2) | raw }}
+configMaps: {{ to_nice_yaml(@('pipeline.base.configMaps'), 2, 2) }}
 
 secrets: {}
 
-persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) | raw }}
+persistence: {{ to_nice_yaml(@('pipeline.base.persistence'), 2, 2) }}


### PR DESCRIPTION
This was there due to an old Workspace version having html escaping set prior to 0.1.3