### PR TITLE
Avoid unnecessary sub-shell for echo piping to stderr

### DIFF
--- a/docker/image/console/root/usr/lib/functions.sh
+++ b/docker/image/console/root/usr/lib/functions.sh
@@ -9,7 +9,7 @@ function db_hasSchema()
         SQL="SELECT CASE WHEN COUNT(*) = 0 THEN 'no' ELSE 'yes' END FROM information_schema.tables WHERE table_catalog = '$DB_NAME' and table_schema='public';"
         IS_DATABASE_APPLIED="$(PGPASSWORD="$DB_PASS" psql -qtAX -h "$DB_HOST" -U "$DB_USER" -c "$SQL")"
     elif [ -n "${DB_PLATFORM}" ]; then
-        (>&2 echo "invalid database type")
+        echo "invalid database type" >&2
         exit 1
     fi
 

--- a/docker/image/console/root/usr/lib/task/assets/apply.sh
+++ b/docker/image/console/root/usr/lib/task/assets/apply.sh
@@ -11,7 +11,7 @@ function task_assets_apply()
         export PGPASSWORD="$DB_PASS"
         IMPORT_COMMAND=(psql -h "$DB_HOST" -U "$DB_USER" "$DB_NAME")
     elif [ -n "${DB_PLATFORM}" ]; then
-        (>&2 echo "invalid database type")
+        echo "invalid database type" >&2
         exit 1
     fi
 

--- a/docker/image/console/root/usr/lib/task/assets/dump.sh
+++ b/docker/image/console/root/usr/lib/task/assets/dump.sh
@@ -16,7 +16,7 @@ function task_assets_dump()
         PRE_COMMAND=("PGPASSWORD=$DB_PASS")
         DUMP_COMMAND=(pg_dump -h "${DB_HOST}" -U "${DB_USER}" "${DB_NAME}")
     elif [ -n "${DB_PLATFORM}" ]; then
-        (>&2 echo "invalid database type")
+        echo "invalid database type" >&2
         exit 1
     fi
 

--- a/docker/image/console/root/usr/lib/task/database/available.sh
+++ b/docker/image/console/root/usr/lib/task/database/available.sh
@@ -12,7 +12,7 @@ function task_database_available()
         # no database is used
         return
     else
-        (>&2 echo "invalid database type")
+        echo "invalid database type" >&2
         exit 1
     fi
 
@@ -21,7 +21,7 @@ function task_database_available()
     while ! $command &> /dev/null; do
 
         if (( counter > 300 )); then
-            (>&2 echo "timeout while waiting on ${DB_PLATFORM} to become available")
+            echo "timeout while waiting on ${DB_PLATFORM} to become available" >&2
             exit 1
         fi
 

--- a/docker/image/console/root/usr/lib/task/http/wait.sh
+++ b/docker/image/console/root/usr/lib/task/http/wait.sh
@@ -9,7 +9,7 @@ function task_http_wait() {
     while ! curl --fail --silent --show-error --location --insecure --output /dev/null "$@"; do
 
         if (( counter > 60 )); then
-            (>&2 echo "timeout while waiting on $1 to become available")
+            echo "timeout while waiting on $1 to become available" >&2
             exit 1
         fi
 


### PR DESCRIPTION
This was creating a bash sub-shell to execute the echo in and link the pipes to, but can do that on echo itself