### PR TITLE
Add searchengine attribute structure to replace elasticsearch

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,25 @@
 # Upgrades
 
+## Upgrading from 0.4.x to 0.4.x
+
+### Attributes moved
+
+* `elasticsearch.host` -> `searchengine.host`
+* `elasticsearch.port` -> `searchengine.port`
+
+### New searchengine configuration and environment variables
+
+In order to allow more options for search engines than elasticsearch, a new attribute structure was created mirroring how database attributes were done.
+
+```yaml
+searchengine:
+  platform: ~ # elasticsearch or opensearch or ~
+  host: # defaults to platform
+  port: 9200
+```
+
+Therefore the old elasticsearch attributes have been replaced with them, and so workspace attributes altering them should change too.
+
 ## Upgrading from 0.2.x to 0.3.x
 
 ### Attributes moved

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,6 @@
 # Upgrades
 
-## Upgrading from 0.4.x to 0.4.x
+## Upgrading from 0.3.x to 0.4.x
 
 ### Attributes moved
 

--- a/docker/image/console/root/usr/lib/task/searchengine/available.sh
+++ b/docker/image/console/root/usr/lib/task/searchengine/available.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function task_searchengine_available()
+{
+    if [ -n "${SEARCHENGINE_PLATFORM:-}" ]; then
+        task http:wait "${SEARCHENGINE_URL:-${SEARCHENGINE_SCHEME:-http}://${SEARCHENGINE_HOST}:${SEARCHENGINE_PORT}}" ${SEARCHENGINE_USERNAME:+--user "${SEARCHENGINE_USERNAME}:${SEARCHENGINE_PASSWORD}"}
+    fi
+}

--- a/harness/attributes/common-01-base.yml
+++ b/harness/attributes/common-01-base.yml
@@ -195,8 +195,10 @@ attributes.default:
     import:
       steps: []
 
-  elasticsearch:
-    host: elasticsearch
+  searchengine:
+    # possible platforms are elasticsearch, opensearch or ~ for none
+    platform: ~
+    host: = @('searchengine.platform')
     port: 9200
 
   domain: my127.site


### PR DESCRIPTION
So that opensearch can be used, with a switch `searchengine.platform` like how `database.platform` is used.