### PR TITLE
[RFC] Add database and searchengine templates for services.*.extends support

### DIFF
--- a/.ci/sample-static-all-services/workspace.yml
+++ b/.ci/sample-static-all-services/workspace.yml
@@ -8,6 +8,10 @@ attribute('app.build'): static
 
 attributes:
   services:
+    console:
+      extends:
+        - _database-access
+        - _searchengine-access
     chrome:
       enabled: true
     elasticsearch:

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -8,14 +8,17 @@ attributes.default:
         DB_PORT: = @('database.port')
         DB_USER: = @('database.user')
         DB_NAME: = @('database.name')
+      environment_secrets:
+        DB_PASS: = @('database.pass')
     _searchengine-access:
       environment:
         SEARCHENGINE_PLATFORM: = @('searchengine.platform')
         SEARCHENGINE_HOST: = @('searchengine.host')
         SEARCHENGINE_PORT: = @('searchengine.port')
         SEARCHENGINE_SCHEME: http
-        # SEARCHENGINE_USERNAME: ~
-        # SEARCHENGINE_PASSWORD: ~
+      #   SEARCHENGINE_USERNAME: ~
+      # environment_secrets:
+      #   SEARCHENGINE_PASSWORD: ~
     console:
       enabled: true
       build:

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -1,5 +1,21 @@
 attributes.default:
   services:
+    _database-access:
+      environment:
+        DB_PLATFORM: = @('database.platform')
+        DB_PLATFORM_VERSION: = @('database.platform_version')
+        DB_HOST: = @('database.host')
+        DB_PORT: = @('database.port')
+        DB_USER: = @('database.user')
+        DB_NAME: = @('database.name')
+    _searchengine-access:
+      environment:
+        SEARCHENGINE_PLATFORM: = @('searchengine.platform')
+        SEARCHENGINE_HOST: = @('searchengine.host')
+        SEARCHENGINE_PORT: = @('searchengine.port')
+        SEARCHENGINE_SCHEME: http
+        # SEARCHENGINE_USERNAME: ~
+        # SEARCHENGINE_PASSWORD: ~
     console:
       enabled: true
       build:


### PR DESCRIPTION
```yaml
attributes:
  services:
    console:
      extends:
        - _database-access
        - _searchengine-access
```

What do people think of this idea?

I don't want to pollute the variables in console in docker harness, and reuse would be needed in PHP harnesses for php-base, so the ignored _service-name syntax (which is also used for _php-base) could be used here.