### PR TITLE
Disable security plugin in elasticsearch and opensearch

### DIFF
--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -18,6 +18,7 @@ attributes.default:
       environment:
         ES_JAVA_OPTS: -Xms512m -Xmx512m
         discovery.type: single-node
+        xpack.security.enabled: "false"
       resources:
         memory: "1024Mi"
     lighthouse:
@@ -54,6 +55,7 @@ attributes.default:
       tag: '2'
       environment:
         OPENSEARCH_JAVA_OPTS: -Xms512m -Xmx512m
+        DISABLE_SECURITY_PLUGIN: 'true'
         discovery.type: single-node
       resources:
         memory: "1024Mi"


### PR DESCRIPTION
It forces https along with username/password. The latter would be fine but https unnecessary effort for self-signed certificate.

This doesn't affect elasticsearch 7, only 8 and opensearch