### PR TITLE
Support passing in true/false string in boolToString()

### DIFF
--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -280,8 +280,8 @@ function('version_compare', [version1, version2, operator]): |
 function('boolToString', [value, true_value, false_value]): |
   #!php
   switch ($value) {
-    case true: return (string) ($trueVal ?? 'yes');
-    case false: return (string) ($falseVal ?? 'no');
+    case true: return (string) ($true_value ?? 'yes');
+    case false: return (string) ($false_value ?? 'no');
   }
   echo 'error: unknown boolean "'.$value.'"'."\n";
   exit(1);

--- a/harness/config/functions.yml
+++ b/harness/config/functions.yml
@@ -277,11 +277,11 @@ function('version_compare', [version1, version2, operator]): |
   $version2 .= str_repeat('.0', max(0, $count1 - $count2));
   = version_compare($version1, $version2, $operator);
 
-function('boolToString', [value]): |
+function('boolToString', [value, true_value, false_value]): |
   #!php
   switch ($value) {
-    case true: return 'yes';
-    case false: return 'no';
+    case true: return (string) ($trueVal ?? 'yes');
+    case false: return (string) ($falseVal ?? 'no');
   }
   echo 'error: unknown boolean "'.$value.'"'."\n";
   exit(1);


### PR DESCRIPTION
Allows passing in optional values like `boolToString(false, 'enable', 'disable')`. Compatible with current one-argument syntax.