### PR TITLE
feat: add support for build args for console

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -33,6 +33,14 @@ attribute('searchengine.platform_version'): 7
 
 If a security fix is needed for the major version though then the tag will also need updating.
 
+### console build environment deprecated
+
+The `services.console.build.environment` attribute is deprecated and may be obsoleted in a future release.
+
+It is recommended instead to use `services.console.build.args` instead, which work similarly for image builds, but the variables are not available at runtime anymore. If they are needed at runtime then also declare them in `services.console.environment`.
+
+It should be noted however, the build arguments are still contained within the image metadata so this still wouldn't remove secrets declared this way.
+
 ## Upgrading from 0.2.x to 0.3.x
 
 ### Attributes moved

--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -7,6 +7,7 @@ services:
     build:
       context: ./
       dockerfile: .my127ws/docker/image/console/Dockerfile
+      args: {{ to_nice_yaml(@('services.console.build.args')|default({}), 2, 8) }}
 {% if @('app.build') == 'dynamic' %}
     entrypoint: [/entrypoint.dynamic.sh]
     command: [sleep, infinity]

--- a/docker/image/console/Dockerfile.twig
+++ b/docker/image/console/Dockerfile.twig
@@ -18,6 +18,13 @@ RUN (getent group "${CODE_OWNER_GROUP}" >/dev/null 2>&1 || groupadd "${CODE_OWNE
  && ([ -e /sbin/tini ] || curl --fail --silent --show-error --location --output /sbin/tini "https://github.com/krallin/tini/releases/download/v0.19.0/tini-$(dpkg --print-architecture)") \
  && chmod +x /sbin/tini
 
+{% set build_args=@('services.console.build.args')|default({})|filter(v => v is not empty) %}
+{% if build_args %}
+{% for name, value in build_args %}
+ARG {{ name }}
+{% endfor %}
+{% endif %}
+
 ENV APP_MODE={{ @('app.mode') }} \
   APP_BUILD={{ @('app.build') }} \
   ASSETS_DIR={{ @('assets.local') }}


### PR DESCRIPTION
These may obsolete build environment as bad practice to template them into the Dockerfile and persist them to be available at runtime