### PR TITLE
Fix harness post-update not having an interpreter

### DIFF
--- a/harness/config/commands.yml
+++ b/harness/config/commands.yml
@@ -228,6 +228,7 @@ command('harness update existing'):
 
 command('harness post-update'):
   exec: |
+    #!bash(workspace:/)
     ws exec app overlay:apply
     ws exec app migrate
     ws exec app welcome


### PR DESCRIPTION
Fix for:
```
■ > ws external-images config ''  | docker compose -f - pull
■ > docker compose up -d --build

 phar:///usr/local/bin/ws.0.3/src/Types/Command/Command.php:34
                                                                                 
 [ERROR] Command "harness post-update" failed due to "Script does not specify an interpreter e.g. `#!php` or `#!bash`." on line 54 
```