### PR TITLE
feat: switch to inviqa chromium image everywhere

### DIFF
--- a/_twig/docker-compose.yml/service/chrome.yml.twig
+++ b/_twig/docker-compose.yml/service/chrome.yml.twig
@@ -1,11 +1,6 @@
 services:
   chrome:
-{% if host_architecture() == 'amd64' %}
-    image: yukinying/chrome-headless-browser:latest
-    command: ["--no-sandbox", "--disable-gpu", "--headless", "--disable-dev-shm-usage", "--remote-debugging-address=0.0.0.0", "--remote-debugging-port=9222", "--user-data-dir=/data"]
-{% else %}
     image: quay.io/inviqa_images/chromium:latest
-{% endif %}
     labels:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false


### PR DESCRIPTION
Ref https://issues.chromium.org/issues/327558594, chromium will no longer bind to 0.0.0.0 for devtools, meaning we have set something up to forward requests.

https://github.com/inviqa/docker-chromium/pull/5 adds socat for this proxying.