### PR TITLE
Add parameters to database availability pings, show waiting message

### DIFF
--- a/docker/image/console/root/usr/lib/task/database/available.sh
+++ b/docker/image/console/root/usr/lib/task/database/available.sh
@@ -5,9 +5,9 @@ function task_database_available()
     local command=""
 
     if [ "${DB_PLATFORM}" == "mysql" ]; then
-        command="mysqladmin -h $DB_HOST -u ${DB_ADMIN_USER:-$DB_USER} -p${DB_ROOT_PASS:-${DB_ADMIN_PASS:-$DB_PASS}} ping --connect_timeout=10"
+        command="mysqladmin -h $DB_HOST -u ${DB_ADMIN_USER:-$DB_USER} -p${DB_ROOT_PASS:-${DB_ADMIN_PASS:-$DB_PASS}} -P ${DB_PORT} ping --connect_timeout=10"
     elif [ "${DB_PLATFORM}" == "postgres" ]; then
-        command="pg_isready -h $DB_HOST"
+        command="pg_isready -h $DB_HOST -U ${DB_ADMIN_USER:-$DB_USER} -p ${DB_PORT}"
     elif [ "${DB_PLATFORM}" == "" ]; then
         # no database is used
         return
@@ -23,6 +23,10 @@ function task_database_available()
         if (( counter > 300 )); then
             echo "timeout while waiting on ${DB_PLATFORM} to become available" >&2
             exit 1
+        fi
+
+        if ! (( counter % 5 )); then
+          echo "Waiting for database to become available: '${command}'"
         fi
 
         sleep 2


### PR DESCRIPTION
Helps a bit with finding out why `task:init` waits forever :) 