### PR TITLE
feat: provide console build args to runtime environment in dynamic mode

### DIFF
--- a/_twig/docker-compose.yml/service/console.yml.twig
+++ b/_twig/docker-compose.yml/service/console.yml.twig
@@ -23,6 +23,7 @@ services:
       # deprecated, a later workspace release will disable by default
       - traefik.enable=false
     environment: {{ to_nice_yaml(deep_merge([
+        @('app.build') == 'dynamic' ? @('services.console.build.args')|default({}) : [],
         @('services.console.environment'),
         @('services.console.environment_dynamic'),
         @('services.console.environment_secrets')


### PR DESCRIPTION
So that they don't need to be specified twice or inadvertently get added to helm values