### PR TITLE
feat: switch to default caching_sha2_password in mysql 8.4

### DIFF
--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -47,7 +47,13 @@ attributes.default:
       image: = @('mysql.image') ~ ':' ~ @('mysql.tag')
       config:
         options:
-          default_authentication_plugin: "= (@('database.platform') == 'mysql' && @('database.platform_version') >= 8.0 && @('database.platform_version') < 10.0 ? 'mysql_native_password' : '')"
+          default_authentication_plugin: >
+            = (
+                @('database.platform') == 'mysql' &&
+                @('database.platform_version') >= 8.0 &&
+                @('database.platform_version') < 8.4
+              ) ? 'mysql_native_password'
+              : ''
           ignore-db-dir: "= (@('database.platform') == 'mysql' && @('database.platform_version') < 8.0 ? 'lost+found' : '')"
           max_allowed_packet: 4M
       environment:

--- a/harness/attributes/docker-01-base.yml
+++ b/harness/attributes/docker-01-base.yml
@@ -50,11 +50,16 @@ attributes.default:
           default_authentication_plugin: >
             = (
                 @('database.platform') == 'mysql' &&
-                @('database.platform_version') >= 8.0 &&
-                @('database.platform_version') < 8.4
+                version_compare(@('database.platform_version'), '8', '>=') &&
+                version_compare(@('database.platform_version'), '8.4', '<')
               ) ? 'mysql_native_password'
               : ''
-          ignore-db-dir: "= (@('database.platform') == 'mysql' && @('database.platform_version') < 8.0 ? 'lost+found' : '')"
+          ignore-db-dir: >
+            = (
+                @('database.platform') == 'mysql' && 
+                version_compare(@('database.platform_version'), '8', '<')
+              ) ? 'lost+found'
+              : ''
           max_allowed_packet: 4M
       environment:
         MYSQL_DATABASE: = @('database.name')


### PR DESCRIPTION
PHP has supported this since PHP 7.4, and mysql 8.4 disables the mysql_native_password plugin by default https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html

It can still be enabled by setting:

```yaml
attribute('service.mysql.config.options'):
  default_authentication_plugin: mysql_native_password
  mysql_native_password: ON
```